### PR TITLE
fix(website): loading-blob + docs tab spacing; clarify render-model wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ASCII polygon-mesh renderer for the DOM — projects 3D meshes into a monospace 
 
 Loads OBJ, glTF, GLB, and MagicaVoxel `.vox` files. Supports wireframe, solid, and voxel render modes with swappable glyph palettes.
 
-> Forked from [polycss](https://github.com/LayoutitStudio/polycss) — the mesh math, parsers (OBJ / glTF / GLB / VOX), scene composition tree, camera math, and input controls carried over intact. The paint backend is rewritten: instead of emitting one CSS-transformed DOM leaf per polygon, the rasteriser walks all polygons, fills a `cols × rows` character grid, and writes a single string to `<pre>.textContent` per frame.
+> Forked from [polycss](https://github.com/LayoutitStudio/polycss) — the mesh math, parsers (OBJ / glTF / GLB / VOX), scene composition tree, camera math, and input controls carried over intact. The paint backend is rewritten: instead of emitting one CSS-transformed DOM leaf per polygon, the rasteriser walks all polygons, fills a `cols × rows` character grid, and writes a single string to `<pre>.textContent` per render.
 
 ## Installation
 
@@ -293,16 +293,18 @@ Supported formats:
 
 ## Performance
 
-glyphcss renders through a single `<pre>` element. The performance envelope is shaped by two things: the number of polygons walked per frame and the size of the character grid written to the DOM.
+glyphcss renders through a single `<pre>` element. The performance envelope is shaped by two things: the number of polygons walked per render and the size of the character grid written to the DOM.
 
-On every camera or scene state change:
+Rendering is change-driven, not a fixed loop: a render is scheduled only when the camera or scene state actually changes, and multiple changes in the same tick are coalesced into a single pass. A static, un-interacted scene performs zero redraws. (Continuous animation — auto-rotate, inertia — does write every frame, but each frame is a genuinely different image.)
+
+On every render pass:
 
 1. All mounted meshes are walked in scene order.
 2. Polygon vertices are transformed through the camera matrix to 2D projected positions.
 3. A `cols × rows` character grid is filled: polygons are depth-tested, each cell picks a glyph from the active palette.
 4. All cells are joined and written to `<pre>.textContent` (or `.innerHTML` for color mode) **exactly once**.
 
-There are no per-polygon DOM elements and no CSS `matrix3d`. Hotspot overlays update via a single `el.style.left/top` assignment per hotspot per frame — not a DOM rebuild.
+There are no per-polygon DOM elements and no CSS `matrix3d`. Hotspot overlays update via a single `el.style.left/top` assignment per hotspot per render — not a DOM rebuild.
 
 `autoSize` uses a `ResizeObserver` to re-fit the grid whenever the host element resizes, keeping the character density constant regardless of viewport size.
 

--- a/website/src/glyph-runtime.ts
+++ b/website/src/glyph-runtime.ts
@@ -650,7 +650,10 @@ function initGlyphDemo(demoEl: HTMLElement): void {
   // a control change. Mesh / polygons-URL demos keep their loaded geometry so a
   // zoom/tilt tweak doesn't replace the mesh with a primitive.
   const usesBuiltInGeometry = !willLoadMesh && !willLoadPrimitive && !willLoadPolygons;
-  let geometry: GeometryState = (willLoadMesh || willLoadPrimitive)
+  // Mesh / primitive / polygons-URL demos start empty so nothing paints until
+  // the real geometry loads — otherwise the built-in default primitive flashes
+  // as a solid blob (the "square") while landing-earth.json is in flight.
+  let geometry: GeometryState = (willLoadMesh || willLoadPrimitive || willLoadPolygons)
     ? { vertices: [[0, 0, 0]], edges: [], polygons: [], animations: [], sample: () => [] }
     : buildDemoGeometry(tunables.geometry);
 

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -442,6 +442,17 @@ html {
   color: var(--gc-orange) !important;
 }
 
+/* Pull the code panel flush against the selector strip — Starlight gives the
+   tab panel a 16px top margin, which reads as a detached box. The landing's
+   tab shell has no gap and looks better, so drop the margin and merge the
+   selector strip's bottom edge into the code frame's top border (one unit). */
+starlight-tabs [role="tabpanel"] {
+  margin-top: 0 !important;
+}
+.tablist-wrapper {
+  border-bottom: 0 !important;
+}
+
 /* ── Right TOC sidebar ────────────────────────────────────────────────────── */
 .right-sidebar {
   font-family: var(--gc-mono) !important;


### PR DESCRIPTION
## Landing — no placeholder blob while the globe loads
`polygonsUrl` demos (the landing earth) fell through to the built-in default geometry, so the default primitive flashed as a **solid filled blob** for the moment it took to fetch + parse `landing-earth.json`. Mesh/primitive demos already start with empty geometry — extended the same treatment to `polygonsUrl`, so the globe shows `Loading…` until the real frame renders.

## Docs — framework tab selectors flush against code
Starlight gives the tab panel a 16px top margin, so the bracket-tab strip and the code frame read as two detached boxes. Zeroed that margin and dropped the strip's bottom border so they merge into one connected unit — matching the landing's tab shell.

## Docs wording — rendering is change-driven
The README said `<pre>.textContent` is written "per frame", which implies an idle redraw loop. It isn't: a render is scheduled only on a camera/scene state change, coalesced to one write per tick; a static scene does zero redraws. Reworded the three "per frame" phrasings to "per render" and added a clarifying paragraph in **Performance**.

Website-only — no package API touched. `pnpm build:website` clean.