### PR TITLE
feat(examples): image → glyph converter + gallery shadows-on default

### DIFF
--- a/website/src/components/ExamplesSidebar.astro
+++ b/website/src/components/ExamplesSidebar.astro
@@ -1,12 +1,13 @@
 ---
 interface Props {
-  active: "world" | "flatmap";
+  active: "world" | "flatmap" | "image";
 }
 const { active } = Astro.props;
 
 const items = [
   { id: "world", label: "World", href: "/examples/world/", desc: "Globe · ETOPO1" },
   { id: "flatmap", label: "Flat Map", href: "/examples/flatmap/", desc: "Iso · Web Mercator" },
+  { id: "image", label: "Image", href: "/examples/image/", desc: "Drop a photo · ASCII" },
 ] as const;
 ---
 

--- a/website/src/components/GalleryWorkbench/GalleryWorkbench.tsx
+++ b/website/src/components/GalleryWorkbench/GalleryWorkbench.tsx
@@ -236,15 +236,15 @@ const DEFAULT_SCENE: SceneOptionsState = {
   fpvCrouchHeight: 0.1,
   fpvLookSensitivity: 0.15,
   fpvInvertY: false,
-  // Shadow — off by default; cast+receive both true so enabling immediately
-  // shows self-shadowing. Floor ON by default so a ground plane appears.
-  shadowEnabled: false,
+  // Shadow — ON by default with cast+receive so every model self-shadows out
+  // of the box. Floor OFF: self-shadowing only, no ground plane.
+  shadowEnabled: true,
   shadowOpacity: 0.25,
   shadowLift: 0.05,
   shadowColor: "#000000",
   shadowCast: true,
   shadowReceive: true,
-  shadowFloor: true,
+  shadowFloor: false,
 };
 
 const EMPTY_METRICS: GlyphMetrics = {

--- a/website/src/pages/examples/image.astro
+++ b/website/src/pages/examples/image.astro
@@ -1,0 +1,294 @@
+---
+import ExamplesSidebar from "../../components/ExamplesSidebar.astro";
+const title = "glyphcss · Image → Glyph";
+---
+
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{title}</title>
+  <style>
+    html, body { background: #04060b; color: #e2e8f0; margin: 0; min-height: 100vh; font-family: ui-monospace, "JetBrains Mono", "SF Mono", monospace; }
+    body { display: flex; }
+    .ex-layout { flex: 1; display: flex; min-height: 100vh; min-width: 0; }
+    .ex-main { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+    .map-head { padding: 20px 28px 10px; border-bottom: 1px solid rgba(255,232,184,0.12); }
+    .map-head h1 { margin: 0; font-size: 20px; color: rgba(255,232,184,0.94); letter-spacing: 0.04em; }
+    .map-head p { margin: 6px 0 0; font-size: 12px; color: rgba(255,232,184,0.5); }
+    .map-stage { flex: 1; min-height: 0; position: relative; overflow: auto; }
+
+    .img-host { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; padding: 16px; }
+    /* The rendered glyph image. white-space pre, per-cell color via spans. */
+    .img-out {
+      margin: 0; font-size: 8px; line-height: 0.6; white-space: pre;
+      font-family: ui-monospace, "JetBrains Mono", "SF Mono", "Menlo", monospace;
+      color: rgba(255,232,184,0.96);
+      letter-spacing: 0; user-select: all;
+    }
+    /* Drop hint shown until an image is loaded */
+    .drop-hint {
+      position: absolute; inset: 24px; border: 1px dashed rgba(255,232,184,0.25);
+      display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px;
+      color: rgba(255,232,184,0.5); font-size: 14px; text-align: center; pointer-events: none;
+    }
+    .drop-hint b { color: rgba(56,189,248,0.9); font-weight: 600; }
+    .drop-hint span { font-size: 11px; color: rgba(255,232,184,0.35); }
+    .map-stage.dragover { background: rgba(56,189,248,0.06); }
+    .map-stage.dragover .drop-hint { border-color: rgba(56,189,248,0.7); color: rgba(56,189,248,0.9); }
+
+    /* Control dock (mirrors flatmap) */
+    .iso-controls {
+      position: absolute; top: 14px; right: 14px; z-index: 10;
+      width: 230px; padding: 12px 14px;
+      background: rgba(8,12,18,0.9); backdrop-filter: blur(4px);
+      border: 1px solid rgba(255,232,184,0.18);
+      font-size: 11px; color: rgba(255,232,184,0.7);
+    }
+    .iso-controls h2 { margin: 0 0 10px; font-size: 11px; letter-spacing: 0.08em; color: rgba(56,189,248,0.9); font-weight: 600; }
+    .iso-ctl { margin-bottom: 11px; }
+    .iso-ctl:last-child { margin-bottom: 0; }
+    .iso-ctl-row { display: flex; justify-content: space-between; margin-bottom: 3px; }
+    .iso-ctl-row .val { color: rgba(255,232,184,0.95); }
+    .iso-ctl input[type="range"] { width: 100%; height: 3px; -webkit-appearance: none; appearance: none; background: rgba(255,232,184,0.2); outline: none; cursor: pointer; }
+    .iso-ctl input[type="range"]::-webkit-slider-thumb { -webkit-appearance: none; appearance: none; width: 12px; height: 12px; background: #38bdf8; border: 1px solid rgba(255,255,255,0.4); cursor: pointer; }
+    .iso-ctl input[type="range"]::-moz-range-thumb { width: 12px; height: 12px; background: #38bdf8; border: 1px solid rgba(255,255,255,0.4); cursor: pointer; border-radius: 0; }
+    .iso-ctl select { width: 100%; font: inherit; font-size: 11px; padding: 3px 4px; background: #0b1018; color: rgba(255,232,184,0.9); border: 1px solid rgba(255,232,184,0.2); cursor: pointer; }
+    .iso-check { display: flex; align-items: center; gap: 7px; cursor: pointer; user-select: none; }
+    .iso-check input { accent-color: #38bdf8; cursor: pointer; }
+    .iso-btn { width: 100%; padding: 6px 0; font: inherit; font-size: 11px; background: rgba(56,189,248,0.1); color: rgba(255,232,184,0.92); border: 1px solid rgba(56,189,248,0.4); cursor: pointer; }
+    .iso-btn:hover { background: rgba(56,189,248,0.2); }
+    .iso-btn:disabled { opacity: 0.4; cursor: default; }
+    .iso-hint { margin-top: 10px; font-size: 10px; color: rgba(255,232,184,0.4); line-height: 1.5; }
+    .map-foot { padding: 12px 28px; border-top: 1px solid rgba(255,232,184,0.12); font-size: 11px; color: rgba(255,232,184,0.45); display: flex; gap: 16px; flex-wrap: wrap; }
+  </style>
+</head>
+<body>
+  <div class="ex-layout">
+    <ExamplesSidebar active="image" />
+    <div class="ex-main">
+      <header class="map-head">
+        <h1>[ IMAGE → GLYPH ]</h1>
+        <p>Drop or paste any image — it's resampled into a glyph grid and painted into one &lt;pre&gt;. Tune resolution, glyph set, color fidelity, and line-height to match the source.</p>
+      </header>
+      <div class="map-stage" id="stage">
+        <div class="img-host">
+          <pre class="img-out" id="out"></pre>
+        </div>
+        <div class="drop-hint" id="hint">
+          <b>Drop an image here</b>
+          <span>or click to choose · or paste from clipboard</span>
+        </div>
+        <input type="file" id="file" accept="image/*" hidden />
+        <div class="iso-controls">
+          <h2>[ CONTROLS ]</h2>
+          <div class="iso-ctl">
+            <div class="iso-ctl-row"><span>resolution (cols)</span><span class="val" id="cols-val">160</span></div>
+            <input type="range" id="cols" min="40" max="360" step="4" value="160" />
+          </div>
+          <div class="iso-ctl">
+            <div class="iso-ctl-row"><span>line-height</span><span class="val" id="lh-val">0.6</span></div>
+            <input type="range" id="lh" min="0.4" max="1.2" step="0.05" value="0.6" />
+          </div>
+          <div class="iso-ctl">
+            <div class="iso-ctl-row"><span>glyph set</span></div>
+            <select id="palette"></select>
+          </div>
+          <div class="iso-ctl">
+            <label class="iso-check"><input type="checkbox" id="color" checked /> color</label>
+          </div>
+          <div class="iso-ctl">
+            <div class="iso-ctl-row"><span>color fidelity</span><span class="val" id="levels-val">24</span></div>
+            <input type="range" id="levels" min="2" max="32" step="1" value="24" />
+          </div>
+          <div class="iso-ctl">
+            <div class="iso-ctl-row"><span>contrast</span><span class="val" id="contrast-val">1.0</span></div>
+            <input type="range" id="contrast" min="0.4" max="2.4" step="0.05" value="1.0" />
+          </div>
+          <div class="iso-ctl">
+            <label class="iso-check"><input type="checkbox" id="invert" /> invert brightness</label>
+          </div>
+          <div class="iso-ctl">
+            <button type="button" class="iso-btn" id="copy" disabled>copy</button>
+          </div>
+          <div class="iso-hint" id="dims"></div>
+        </div>
+      </div>
+      <footer class="map-foot">
+        <span>glyphcss palettes · resampled client-side</span>
+        <span id="status">no image</span>
+      </footer>
+    </div>
+  </div>
+
+  <script>
+    import { WIREFRAME_PALETTES } from "glyphcss";
+
+    const stage = document.getElementById("stage") as HTMLElement;
+    const out = document.getElementById("out") as HTMLPreElement;
+    const hint = document.getElementById("hint") as HTMLElement;
+    const fileInput = document.getElementById("file") as HTMLInputElement;
+    const paletteSel = document.getElementById("palette") as HTMLSelectElement;
+    const copyBtn = document.getElementById("copy") as HTMLButtonElement;
+    const dims = document.getElementById("dims") as HTMLElement;
+    const statusEl = document.getElementById("status") as HTMLElement;
+
+    // Populate the glyph-set dropdown from the library's named palettes.
+    for (const name of Object.keys(WIREFRAME_PALETTES)) {
+      const opt = document.createElement("option");
+      opt.value = name; opt.textContent = name;
+      paletteSel.appendChild(opt);
+    }
+    paletteSel.value = "default";
+
+    const ctl = {
+      cols: document.getElementById("cols") as HTMLInputElement,
+      lh: document.getElementById("lh") as HTMLInputElement,
+      color: document.getElementById("color") as HTMLInputElement,
+      levels: document.getElementById("levels") as HTMLInputElement,
+      contrast: document.getElementById("contrast") as HTMLInputElement,
+      invert: document.getElementById("invert") as HTMLInputElement,
+    };
+    const valEls: Record<string, HTMLElement> = {
+      cols: document.getElementById("cols-val")!,
+      lh: document.getElementById("lh-val")!,
+      levels: document.getElementById("levels-val")!,
+      contrast: document.getElementById("contrast-val")!,
+    };
+
+    let img: HTMLImageElement | null = null;
+
+    // Measure one monospace cell (width vs line-height-driven height) so rows are
+    // derived to keep the source aspect ratio regardless of font / line-height.
+    function cellAspect(): number {
+      const fs = parseFloat(getComputedStyle(out).fontSize) || 8;
+      const probe = document.createElement("span");
+      probe.style.cssText = `position:absolute;visibility:hidden;font:${getComputedStyle(out).font};white-space:pre`;
+      probe.textContent = "M".repeat(40);
+      document.body.appendChild(probe);
+      const charW = probe.getBoundingClientRect().width / 40;
+      probe.remove();
+      const charH = fs * parseFloat(ctl.lh.value);
+      return charH / (charW || fs * 0.6);
+    }
+
+    const sampler = document.createElement("canvas");
+    const sctx = sampler.getContext("2d", { willReadFrequently: true })!;
+
+    function render(): void {
+      out.style.lineHeight = ctl.lh.value;
+      if (!img) return;
+      const cols = parseInt(ctl.cols.value, 10);
+      const aspect = cellAspect();
+      const rows = Math.max(1, Math.round((cols * img.naturalHeight) / (img.naturalWidth * aspect)));
+      sampler.width = cols; sampler.height = rows;
+      sctx.clearRect(0, 0, cols, rows);
+      sctx.drawImage(img, 0, 0, cols, rows);
+      const data = sctx.getImageData(0, 0, cols, rows).data;
+
+      const ramp = (WIREFRAME_PALETTES[paletteSel.value] ?? WIREFRAME_PALETTES.default!).solid;
+      const rampMax = ramp.length - 1;
+      const useColor = ctl.color.checked;
+      const levels = parseInt(ctl.levels.value, 10);
+      const contrast = parseFloat(ctl.contrast.value);
+      const invert = ctl.invert.checked;
+      const qstep = 255 / (levels - 1);
+
+      // Build HTML, coalescing consecutive same-color glyphs into one <span>.
+      const parts: string[] = [];
+      let runColor: string | null = null;
+      let runText = "";
+      const flush = () => {
+        if (!runText) return;
+        parts.push(runColor !== null ? `<span style="color:${runColor}">${runText}</span>` : runText);
+        runText = "";
+      };
+      for (let y = 0; y < rows; y++) {
+        for (let x = 0; x < cols; x++) {
+          const i = (y * cols + x) * 4;
+          const r = data[i]!, g = data[i + 1]!, bl = data[i + 2]!, a = data[i + 3]!;
+          // Luminance → contrast → ramp index.
+          let lum = (0.299 * r + 0.587 * g + 0.114 * bl) * (a / 255);
+          lum = (lum - 128) * contrast + 128;
+          let t = Math.min(1, Math.max(0, lum / 255));
+          if (invert) t = 1 - t;
+          const glyph = ramp[Math.min(rampMax, Math.max(0, Math.round(t * rampMax)))]!;
+          let color: string | null = null;
+          if (useColor && glyph !== " " && a > 8) {
+            const qr = Math.round(Math.round(r / qstep) * qstep);
+            const qg = Math.round(Math.round(g / qstep) * qstep);
+            const qb = Math.round(Math.round(bl / qstep) * qstep);
+            color = `#${((1 << 24) + (qr << 16) + (qg << 8) + qb).toString(16).slice(1)}`;
+          }
+          if (color !== runColor) { flush(); runColor = color; }
+          runText += glyph;
+        }
+        flush();
+        runColor = null;
+        if (y < rows - 1) parts.push("\n");
+      }
+      if (useColor) out.innerHTML = parts.join("");
+      else out.textContent = parts.join("");
+      dims.textContent = `${cols} × ${rows} cells · ${ramp.length}-step ${paletteSel.value}`;
+      copyBtn.disabled = false;
+      statusEl.textContent = `${cols}×${rows}`;
+    }
+
+    function loadFile(file: File): void {
+      if (!file || !file.type.startsWith("image/")) return;
+      const url = URL.createObjectURL(file);
+      const im = new Image();
+      im.onload = () => { img = im; hint.style.display = "none"; URL.revokeObjectURL(url); render(); };
+      im.src = url;
+      statusEl.textContent = `loading ${file.name}…`;
+    }
+
+    // Controls
+    for (const el of Object.values(ctl)) el.addEventListener("input", render);
+    paletteSel.addEventListener("change", render);
+    for (const k of Object.keys(valEls)) ctl[k as keyof typeof ctl].addEventListener("input", () => { valEls[k]!.textContent = ctl[k as keyof typeof ctl].value; });
+
+    // Drop / click / paste
+    fileInput.addEventListener("change", () => { if (fileInput.files?.[0]) loadFile(fileInput.files[0]); });
+    hint.parentElement!.addEventListener("click", (e) => { if (!img && (e.target === hint || (e.target as Element).closest(".drop-hint"))) fileInput.click(); });
+    stage.addEventListener("dragover", (e) => { e.preventDefault(); stage.classList.add("dragover"); });
+    stage.addEventListener("dragleave", () => stage.classList.remove("dragover"));
+    stage.addEventListener("drop", (e) => {
+      e.preventDefault(); stage.classList.remove("dragover");
+      const f = e.dataTransfer?.files?.[0];
+      if (f) loadFile(f);
+    });
+    window.addEventListener("paste", (e) => {
+      const item = [...(e.clipboardData?.items ?? [])].find((it) => it.type.startsWith("image/"));
+      const f = item?.getAsFile();
+      if (f) loadFile(f);
+    });
+
+    // Copy both plain text and rich HTML so color survives a paste into rich
+    // editors (mirrors the gallery's Copy). The colored <span>s are kept inside
+    // a dark-background <pre> so the pasted result reads like the on-screen one.
+    copyBtn.addEventListener("click", async () => {
+      const text = out.textContent ?? "";
+      const html =
+        `<pre style="font-family:ui-monospace,'JetBrains Mono','SF Mono',Menlo,monospace;` +
+        `white-space:pre;line-height:${ctl.lh.value};background:#04060b;` +
+        `color:rgba(255,232,184,0.96);margin:0;padding:10px">${out.innerHTML}</pre>`;
+      const done = () => { copyBtn.textContent = "copied!"; setTimeout(() => (copyBtn.textContent = "copy"), 1200); };
+      try {
+        const CI = (globalThis as { ClipboardItem?: typeof ClipboardItem }).ClipboardItem;
+        if (CI && navigator.clipboard?.write) {
+          await navigator.clipboard.write([new CI({
+            "text/plain": new Blob([text], { type: "text/plain" }),
+            "text/html": new Blob([html], { type: "text/html" }),
+          })]);
+        } else {
+          await navigator.clipboard.writeText(text);
+        }
+        done();
+      } catch {
+        try { await navigator.clipboard.writeText(text); done(); } catch { /* clipboard blocked */ }
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Adds an **Image → Glyph** example (drop/paste any image → resampled into a glyph grid in one `<pre>`) with sidebar controls: resolution, line-height, glyph set (all 12 palettes), color toggle, color fidelity (RGB quantization), contrast, invert. Copy writes both plain text and rich HTML so color survives a paste (mirrors the gallery). Also flips the gallery default to shadows on (cast+receive), floor off. Website-only; `pnpm build:website` green.