### PR TITLE
feat(render): perspective FPV camera, BSP-surface fidelity, and depth correctness

### DIFF
--- a/packages/glyphcss/src/api/createGlyphCamera.ts
+++ b/packages/glyphcss/src/api/createGlyphCamera.ts
@@ -16,6 +16,27 @@ const BASE_TILE = 50;
 const DEG = Math.PI / 180;
 
 /**
+ * Perspective near plane as a fraction of the perspective distance `P`. The
+ * clipped-vertex projection scale is `P / near = 1 / fraction`, so 0.01 caps it
+ * to ~100× — small enough not to clip visible geometry, large enough that
+ * near-clipped triangles stay numerically stable instead of jittering.
+ */
+const PERSPECTIVE_NEAR_FRACTION = 0.01;
+
+/**
+ * Near fraction used by `eyeDepth` for near-plane CLIPPING — deliberately a hair
+ * larger than the projection's `PERSPECTIVE_NEAR_FRACTION`. The clip plane sits
+ * at `eyeDepth = 0`, which puts the interpolated crossing vertices exactly there;
+ * if that coincided with the projection's near plane, those crossings would
+ * reproject to `denom ≈ NEAR ± rounding` and the `denom < NEAR` test would reject
+ * a hair of them as NaN — collapsing the clipped triangle and dropping the whole
+ * polygon (e.g. the floor right under the camera vanishes when looking down). By
+ * clipping a hair INSIDE the frustum, every surviving + crossing vertex has
+ * `denom` safely above the projection near plane and projects to a finite point.
+ */
+const PERSPECTIVE_CLIP_NEAR_FRACTION = PERSPECTIVE_NEAR_FRACTION * 1.01;
+
+/**
  * Apply voxcss's world→screen rotation convention to a world-space vector.
  *
  * voxcss `getStyle()` transform order (right-to-left for points):
@@ -70,6 +91,12 @@ export interface GlyphCamera {
   /** Distance from target along the view axis. For perspective cameras: world units. Default 0. */
   distance: number;
   /**
+   * CSS-perspective distance in virtual pixels (voxcss parity). When > 0, the
+   * camera projects with the browser's `P / (P − z)` CSS-perspective math.
+   * Default 0 (disabled).
+   */
+  perspective: number;
+  /**
    * Camera zoom — CSS scale multiplier (same semantic as voxcss).
    * `zoom = 1` → one world unit = BASE_TILE (50) virtual pixels.
    * Larger values zoom in; smaller zoom out. NOT a fraction of viewport.
@@ -77,6 +104,16 @@ export interface GlyphCamera {
   zoom: number;
   /** Extra horizontal stretch on top of `cellAspect`. */
   stretch: number;
+  /**
+   * Isotropic field-of-view scale applied to the projected screen offset (around
+   * the center), independent of the perspective divide. `1` = off. Use it to
+   * decouple the FOV from the grid resolution: when the grid grows (e.g. a
+   * smaller line-height adds rows), the FOV would otherwise widen — set
+   * `fovScale` proportional to the resolution change to keep it fixed. Unlike
+   * `zoom`, it does NOT alter perspective foreshortening (zoom scales `cssZ`,
+   * shifting the `P/(P−z)` divide; this only scales the post-divide offset).
+   */
+  fovScale: number;
   /**
    * Camera target offset in world space — shifts the point the camera orbits around.
    * Subtracted from world coords before projection so the mesh appears to pan without re-baking.
@@ -89,8 +126,27 @@ export interface GlyphCamera {
    * `createGlyphFirstPersonControls` at attach / detach time.
    */
   eyeMode: boolean;
-  /** Project a world-space vector to `[col, row, depth]`. Same projection used by the renderer and the hit layer. */
-  project(v: Vec3, cols: number, rows: number, cellAspect: number): [number, number, number];
+  /**
+   * Project a world-space vector to `[col, row, depth, zbuf?]`. `depth` is the
+   * linear eye-space `cssZ` (the public contract, used by the hit layer). The
+   * optional 4th element `zbuf` is the **screen-space-linear** depth (`1/denom`)
+   * for perspective cameras — the renderer's z-buffer must use it (not `depth`)
+   * so the depth test is perspective-correct: interpolating linear `cssZ` with
+   * screen-space barycentric weights misorders overlapping triangles, which
+   * shows the wrong (farther) surface in some cells and flickers under motion.
+   * Orthographic cameras omit it (their linear `depth` is already screen-linear).
+   */
+  project(v: Vec3, cols: number, rows: number, cellAspect: number): [number, number, number, number?];
+  /**
+   * Signed distance of a world vertex past the near plane: `> 0` is visible
+   * (in front of the near plane), `<= 0` is culled (at/behind the eye). The
+   * near plane sits at `eyeDepth = 0`, so an edge crossing the near plane is
+   * found by linear interpolation where `eyeDepth` changes sign. The renderer
+   * uses this for near-plane clipping; `eyeDepth` is affine in `v`, so the
+   * world-space crossing point interpolates linearly. Orthographic cameras
+   * return `+Infinity` (never clipped).
+   */
+  eyeDepth(v: Vec3): number;
 }
 
 export interface GlyphPerspectiveCameraOptions {
@@ -110,6 +166,16 @@ export interface GlyphPerspectiveCameraOptions {
    */
   distance?: number;
   /**
+   * CSS-perspective distance in **virtual pixels**, matching voxcss/polycss
+   * `createPolyPerspectiveCamera({ perspective })`. When > 0, the camera projects
+   * with the same `P / (P − z)` pinhole math the browser applies for CSS
+   * `perspective: Npx` — so identical camera params (rotX/rotY/target/zoom/
+   * distance/perspective) produce the same on-screen projection as polycss, and
+   * a first-person view falls out naturally (no `eyeMode` needed). Default 0
+   * (disabled → legacy orbit/eyeMode projection).
+   */
+  perspective?: number;
+  /**
    * Camera zoom — CSS scale multiplier. Default 0.3.
    * `zoom = 1` → BASE_TILE (50) virtual px per world unit.
    */
@@ -119,6 +185,8 @@ export interface GlyphPerspectiveCameraOptions {
    * over-stretching when monospace cells are taller than wide. Default 1.0.
    */
   stretch?: number;
+  /** Isotropic FOV scale on the projected offset (resolution-independent FOV). Default 1. */
+  fovScale?: number;
   /** Center of projection in normalized grid coords. Default `[0.5, 0.5]`. */
   center?: [number, number];
 }
@@ -147,8 +215,10 @@ export function createGlyphPerspectiveCamera(opts: GlyphPerspectiveCameraOptions
     rotX: opts.rotX ?? 65,
     rotY: opts.rotY ?? 45,
     distance: opts.distance ?? 6,
+    perspective: opts.perspective ?? 0,
     zoom: opts.zoom ?? 0.65,
     stretch: opts.stretch ?? 1.0,
+    fovScale: opts.fovScale ?? 1.0,
     target: [0, 0, 0] as Vec3,
     eyeMode: false,
     // Focal length used in eye mode (world units). Governs how "tight" the
@@ -166,14 +236,38 @@ export function createGlyphPerspectiveCamera(opts: GlyphPerspectiveCameraOptions
     set rotY(v: number) { state.rotY = v; },
     get distance(): number { return state.distance; },
     set distance(v: number) { state.distance = v; },
+    get perspective(): number { return state.perspective; },
+    set perspective(v: number) { state.perspective = v; },
     get zoom(): number { return state.zoom; },
     set zoom(v: number) { state.zoom = v; },
     get stretch(): number { return state.stretch; },
     set stretch(v: number) { state.stretch = v; },
+    get fovScale(): number { return state.fovScale; },
+    set fovScale(v: number) { state.fovScale = v; },
     get target(): Vec3 { return state.target; },
     set target(v: Vec3) { state.target = v; },
     get eyeMode(): boolean { return state.eyeMode; },
     set eyeMode(v: boolean) { state.eyeMode = v; },
+    eyeDepth(v) {
+      const r = rotateVec3Voxcss(
+        [v[0] - state.target[0], v[1] - state.target[1], v[2] - state.target[2]],
+        state.rotX,
+        state.rotY,
+      );
+      if (state.perspective > 0) {
+        const cssZ = r[2] * state.zoom * BASE_TILE - state.distance;
+        // Near plane at 1% of the perspective distance, not ~on the eye: a
+        // vertex right on the eye projects with `perspScale = P/near = ∞`,
+        // which makes near-clipped triangles jitter wildly as the camera moves.
+        // Bounding `near` to `P/100` caps that to ~100× and kills the jitter.
+        return (state.perspective - cssZ) - state.perspective * PERSPECTIVE_CLIP_NEAR_FRACTION;
+      }
+      // Clip a hair inside the projection near plane (0.001) for the same reason
+      // as the perspective branch — crossing vertices must reproject finitely.
+      const NEAR = 0.001 * 1.01;
+      if (state.eyeMode) return (-r[2]) - NEAR;
+      return (state.distance - r[2]) - NEAR;
+    },
     project(v, cols, rows, cellAspect) {
       // Virtual char-cell pixel sizes (world-unit-to-cell conversion).
       // cellAspect = cellPxH / cellPxW; we define BASE_TILE as cellPxH so that
@@ -189,12 +283,44 @@ export function createGlyphPerspectiveCamera(opts: GlyphPerspectiveCameraOptions
       ];
       const r = rotateVec3Voxcss(shifted, state.rotX, state.rotY);
 
+      if (state.perspective > 0) {
+        // voxcss / CSS-perspective parity projection.
+        //
+        // Reproduces exactly what the browser does for polycss: the camera
+        // transform `translateZ(-distance) scale(zoom) rotateX rotate
+        // translate3d(-target)` followed by the container's CSS
+        // `perspective: P` (which applies `P / (P − z)` about the centre).
+        //
+        // r is the rotated vector in world units; convert to CSS px the same
+        // way voxcss does (× zoom × BASE_TILE), pull back by `distance` px,
+        // then apply the perspective divide. `target` is the world point at the
+        // screen centre, so placing it ahead of the player makes the eye land
+        // on the player → first-person, no eyeMode flag required.
+        const P = state.perspective;
+        const cssX = r[0] * state.zoom * BASE_TILE;
+        const cssY = r[1] * state.zoom * BASE_TILE;
+        const cssZ = r[2] * state.zoom * BASE_TILE - state.distance;
+        const denom = P - cssZ;
+        // Near plane at `P/100` (not ~0): keeps `perspScale = P/denom` bounded so
+        // near-clipped triangles don't jitter. Geometry nearer than this is
+        // clipped, matching how CSS hides geometry past the perspective origin.
+        const NEAR = P * PERSPECTIVE_NEAR_FRACTION;
+        if (denom < NEAR) return [NaN, NaN, cssZ, NaN];
+        const perspScale = P / denom;
+        const col = cols * cxN + (cssX * perspScale) / cellPxW * state.stretch * state.fovScale;
+        const row = rows * cyN + (cssY * perspScale) / cellPxH * state.fovScale;
+        // zbuf = 1/denom: affine in screen space, so barycentric interpolation
+        // is exact. Nearer (larger cssZ → smaller denom) → larger 1/denom, so
+        // the renderer's `pixelDepth > depthBuf` keeps the nearer surface.
+        return [col, row, cssZ, 1 / denom];
+      }
+
       if (state.eyeMode) {
         // Eye-at-origin first-person projection.
         // `target` is the eye position; rz2 < 0 means in front of the eye.
         // Perspective scale: objects at depth -d project at scale focal/d.
         const NEAR = 0.001;
-        if (r[2] >= -NEAR) return [NaN, NaN, r[2]];
+        if (r[2] >= -NEAR) return [NaN, NaN, r[2], NaN];
         // Perspective scale in world units. state.focal is the reference depth
         // (distance of the "screen plane" from the eye).
         const perspScale = state.focal / -r[2];
@@ -203,7 +329,8 @@ export function createGlyphPerspectiveCamera(opts: GlyphPerspectiveCameraOptions
         const screenPxY = r[1] * perspScale * state.zoom * BASE_TILE;
         const col = cols * cxN + screenPxX / cellPxW * state.stretch;
         const row = rows * cyN + screenPxY / cellPxH;
-        return [col, row, r[2]];
+        // zbuf = -1/r[2]: screen-space-linear (r[2] < 0 in front; nearer → larger).
+        return [col, row, r[2], -1 / r[2]];
       }
 
       // Perspective projection (orthographic when distance is very large).
@@ -212,15 +339,16 @@ export function createGlyphPerspectiveCamera(opts: GlyphPerspectiveCameraOptions
       // pinhole camera at depth `distance` looking toward +Z.
       const NEAR = 0.001;
       const denom = state.distance - r[2];
-      if (denom < NEAR) return [NaN, NaN, r[2]];
+      if (denom < NEAR) return [NaN, NaN, r[2], NaN];
       const perspScale = state.distance / denom;
 
       // world→screen-px→char-cell
       const screenPxX = r[0] * perspScale * state.zoom * BASE_TILE;
       const screenPxY = r[1] * perspScale * state.zoom * BASE_TILE;
-      const col = cols * cxN + screenPxX / cellPxW * state.stretch;
-      const row = rows * cyN + screenPxY / cellPxH;
-      return [col, row, r[2]];
+      const col = cols * cxN + screenPxX / cellPxW * state.stretch * state.fovScale;
+      const row = rows * cyN + screenPxY / cellPxH * state.fovScale;
+      // zbuf = 1/denom: screen-space-linear (nearer → smaller denom → larger).
+      return [col, row, r[2], 1 / denom];
     },
   };
 }
@@ -232,6 +360,7 @@ export function createGlyphOrthographicCamera(opts: GlyphOrthographicCameraOptio
     distance: 0,
     zoom: opts.zoom ?? 0.65,
     stretch: 1.0,
+    fovScale: 1.0,
     target: [0, 0, 0] as Vec3,
   };
   const [cxN, cyN] = opts.center ?? [0.5, 0.5];
@@ -244,16 +373,23 @@ export function createGlyphOrthographicCamera(opts: GlyphOrthographicCameraOptio
     set rotY(v: number) { state.rotY = v; },
     get distance(): number { return state.distance; },
     set distance(v: number) { state.distance = v; },
+    // Orthographic projection has no perspective; field satisfies the interface.
+    get perspective(): number { return 0; },
+    set perspective(_v: number) { /* no-op — orthographic projection has no perspective */ },
     get zoom(): number { return state.zoom; },
     set zoom(v: number) { state.zoom = v; },
     get stretch(): number { return state.stretch; },
     set stretch(v: number) { state.stretch = v; },
+    get fovScale(): number { return state.fovScale; },
+    set fovScale(v: number) { state.fovScale = v; },
     get target(): Vec3 { return state.target; },
     set target(v: Vec3) { state.target = v; },
     // Orthographic cameras never use eye-mode projection. The setter is a no-op
     // so the field satisfies the GlyphCamera interface.
     get eyeMode(): boolean { return false; },
     set eyeMode(_v: boolean) { /* no-op — orthographic projection has no eye mode */ },
+    // Orthographic projection has no eye, so nothing is ever near-clipped.
+    eyeDepth(_v) { return Number.POSITIVE_INFINITY; },
     project(v, cols, rows, cellAspect) {
       // Virtual char-cell pixel sizes (see perspective camera for derivation).
       const cellPxH = BASE_TILE;
@@ -269,8 +405,8 @@ export function createGlyphOrthographicCamera(opts: GlyphOrthographicCameraOptio
       // Orthographic: no perspective divide.
       const screenPxX = r[0] * state.zoom * BASE_TILE;
       const screenPxY = r[1] * state.zoom * BASE_TILE;
-      const col = cols * cxN + screenPxX / cellPxW;
-      const row = rows * cyN + screenPxY / cellPxH;
+      const col = cols * cxN + screenPxX / cellPxW * state.fovScale;
+      const row = rows * cyN + screenPxY / cellPxH * state.fovScale;
       return [col, row, r[2]];
     },
   };

--- a/packages/glyphcss/src/api/createGlyphScene.ts
+++ b/packages/glyphcss/src/api/createGlyphScene.ts
@@ -30,7 +30,7 @@ import type {
 import type { GlyphCamera } from "./createGlyphCamera";
 import { createGlyphPerspectiveCamera } from "./createGlyphCamera";
 import { buildRasterizeContext } from "./rasterizeContext";
-import type { ShadeCache } from "./rasterizeContext";
+import type { ShadeCache, TemporalHistory } from "./rasterizeContext";
 import { rasterize } from "../render/rasterize";
 import { injectGlyphBaseStyles } from "../styles/styles";
 import { projectHotspots } from "./projectHotspots";
@@ -71,6 +71,32 @@ export interface GlyphSceneOptions {
    * Default `60`.
    */
   creaseAngle?: number;
+  /**
+   * Render both faces of every polygon (no backface culling). Default `false`.
+   * Set `true` for single-sided surfaces whose winding isn't guaranteed to face
+   * the camera — e.g. BSP level geometry — so "back-wound" faces don't vanish,
+   * matching how a CSS/DOM renderer shows both sides.
+   */
+  doubleSided?: boolean;
+  /**
+   * Supersampled anti-aliasing (solid mode). `1` (default) = off; `2`/`3`
+   * rasterize at N× resolution and average down, removing the motion crawl of
+   * sub-cell-sized surfaces. Cost ~N².
+   */
+  supersample?: number;
+  /**
+   * Global depth-test deadband (0 = exact, default). A polygon replaces a cell
+   * only when nearer by more than this relative fraction, so near-coplanar
+   * surfaces keep a stable winner instead of z-fighting per-cell as the camera
+   * moves (the tearing a CSS/DOM renderer avoids via stacking order). 0.002–0.01.
+   */
+  depthEpsilon?: number;
+  /**
+   * Temporal anti-aliasing — exponential blend with the previous frame, weight
+   * in [0,1). `0` (default) = off. Smooths fast frame-to-frame edge crawl that
+   * supersampling can't cover, at the cost of motion ghosting.
+   */
+  temporalBlend?: number;
   /**
    * Auto-size the character grid to fill the host element. When `true`, the
    * scene measures one monospace character's pixel size from the live `<pre>`
@@ -216,6 +242,10 @@ export function createGlyphScene(
     camera: opts.camera ?? createGlyphPerspectiveCamera(),
     smoothShading: opts.smoothShading ?? false,
     creaseAngle: opts.creaseAngle ?? 60,
+    doubleSided: opts.doubleSided ?? false,
+    supersample: opts.supersample ?? 1,
+    depthEpsilon: opts.depthEpsilon ?? 0,
+    temporalBlend: opts.temporalBlend ?? 0,
     autoSize: opts.autoSize ?? false,
     shadow: opts.shadow,
   };
@@ -241,6 +271,10 @@ export function createGlyphScene(
   // options change. Shadow changes do NOT invalidate it — shadows are blended
   // per cell at scan-fill, not baked into the cached lit color.
   const shadeCache: ShadeCache = { iA: [], iB: [], iC: [], lit: [] };
+  // Retained previous-frame buffer for temporal AA; `rasterize` resizes/seeds it.
+  const temporalHistory: TemporalHistory = {
+    idx: new Float32Array(0), r: new Float32Array(0), g: new Float32Array(0), b: new Float32Array(0), cols: 0, rows: 0, cam: null,
+  };
   function invalidateShading(): void {
     shadeCache.iA.length = 0;
     shadeCache.iB.length = 0;
@@ -262,14 +296,19 @@ export function createGlyphScene(
     const allPolygons: Polygon[] = [];
     const castShadowFlags: boolean[] = [];
     const receiveShadowFlags: boolean[] = [];
+    const depthBiases: number[] = [];
+    let anyDepthBias = false;
     for (const entry of meshes.values()) {
       const transformed = applyTransform(entry.polygons, entry.transform);
       const cast = entry.transform.castShadow ?? false;
       const receive = entry.transform.receiveShadow ?? false;
+      const bias = entry.transform.depthBias ?? 0;
+      if (bias !== 0) anyDepthBias = true;
       for (const p of transformed) {
         allPolygons.push(p);
         castShadowFlags.push(cast);
         receiveShadowFlags.push(receive);
+        depthBiases.push(bias);
       }
     }
 
@@ -284,11 +323,17 @@ export function createGlyphScene(
       useColors: options.useColors,
       smoothShading: options.smoothShading,
       creaseAngle: options.creaseAngle,
+      doubleSided: options.doubleSided,
+      supersample: options.supersample,
+      depthEpsilon: options.depthEpsilon,
+      temporalBlend: options.temporalBlend,
       shadow: options.shadow,
       castShadowFlags,
       receiveShadowFlags,
+      depthBiases: anyDepthBias ? depthBiases : undefined,
     });
     ctx.shadeCache = shadeCache;
+    ctx.temporalHistory = temporalHistory;
 
     // Optional perf instrumentation: set `globalThis.__glyphPerf = {}` to
     // record per-render rasterize vs DOM-write timings into it. Zero cost when

--- a/packages/glyphcss/src/api/rasterizeContext.ts
+++ b/packages/glyphcss/src/api/rasterizeContext.ts
@@ -38,11 +38,45 @@ export interface RasterizeContextOptions {
    * shading; `180` smooths every shared vertex. Default `60`.
    */
   creaseAngle?: number;
+  /**
+   * Render both faces of every polygon (no backface culling). Default `false`
+   * (cull back faces — correct + faster for closed meshes). Set `true` for
+   * single-sided surfaces whose winding isn't guaranteed to face the camera —
+   * e.g. level geometry imported from a BSP — matching how a CSS/DOM renderer
+   * (polycss) shows both sides. Without it, "back-wound" faces vanish.
+   */
+  doubleSided?: boolean;
+  /**
+   * Supersampled anti-aliasing factor (solid mode). `1` (default) = off. `2`/`3`
+   * rasterize at N× the grid resolution and box-average down, removing the
+   * motion crawl where sub-cell-sized surfaces flip their per-cell winner
+   * frame-to-frame. Cost scales ~N². Use `2` for a big stability win at ~4× cost.
+   */
+  supersample?: number;
+  /**
+   * Temporal anti-aliasing: exponential blend of this frame with the previous
+   * one, weight in [0,1) (history weight). `0` (default) = off. Smooths the
+   * frame-to-frame crawl of edges that move faster than spatial supersampling
+   * can cover, at the cost of motion ghosting. Needs `temporalHistory` retained
+   * across renders (the scene does this).
+   */
+  temporalBlend?: number;
   shadow?: GlyphShadowOptions;
   /** Per-polygon cast flag (parallel to `polygons` array). True = this poly's mesh has castShadow. */
   castShadowFlags?: boolean[];
   /** Per-polygon receive flag (parallel to `polygons` array). True = this poly's mesh has receiveShadow. */
   receiveShadowFlags?: boolean[];
+  /** Per-polygon relative depth bias (parallel to `polygons`). `pixelDepth *= 1 + bias`. */
+  depthBiases?: number[];
+  /**
+   * Global depth-test deadband (0 = exact, the default). A polygon replaces the
+   * current cell only when nearer by more than this relative fraction, so
+   * near-coplanar surfaces (overlapping brushes, decals, a translucent plane
+   * over its backing face) keep a STABLE winner instead of z-fighting per-cell
+   * as the camera moves. A CSS/DOM renderer gets this for free from stacking
+   * order; a projection-painted depth buffer needs the deadband. Typical 0.002–0.01.
+   */
+  depthEpsilon?: number;
 }
 
 /**
@@ -60,6 +94,25 @@ export interface ShadeCache {
   lit: (string | null)[];
 }
 
+/**
+ * Retained previous-frame buffer for temporal anti-aliasing. Per output cell:
+ * blended ramp index + RGB. The scene keeps one and reuses it across renders;
+ * `rasterize` resets it when the grid size changes.
+ */
+export interface TemporalHistory {
+  idx: Float32Array;
+  r: Float32Array;
+  g: Float32Array;
+  b: Float32Array;
+  cols: number;
+  rows: number;
+  /** Snapshot of the camera that produced the stored frame (for reprojection). */
+  cam: {
+    rotX: number; rotY: number; target: [number, number, number];
+    zoom: number; perspective: number; distance: number; stretch: number;
+  } | null;
+}
+
 export interface RasterizeContext {
   camera: GlyphCamera;
   grid: GridSize;
@@ -73,11 +126,19 @@ export interface RasterizeContext {
   useColors: boolean;
   smoothShading: boolean;
   creaseAngle: number;
+  doubleSided: boolean;
+  supersample: number;
+  temporalBlend: number;
   shadow: GlyphShadowOptions | undefined;
   castShadowFlags: boolean[];
   receiveShadowFlags: boolean[];
+  depthBiases?: number[];
+  /** Global depth-test deadband — see {@link RasterizeContextOptions.depthEpsilon}. */
+  depthEpsilon?: number;
   /** Optional cross-frame shading cache (see {@link ShadeCache}). */
   shadeCache?: ShadeCache | null;
+  /** Optional retained previous-frame buffer for temporal AA. */
+  temporalHistory?: TemporalHistory | null;
 }
 
 // Direction the light shines TOWARD (three.js / computeShapeLighting convention).
@@ -127,8 +188,13 @@ export function buildRasterizeContext(opts: RasterizeContextOptions): RasterizeC
     useColors: opts.useColors ?? true,
     smoothShading: opts.smoothShading ?? false,
     creaseAngle: opts.creaseAngle ?? 60,
+    doubleSided: opts.doubleSided ?? false,
+    supersample: opts.supersample ?? 1,
+    temporalBlend: opts.temporalBlend ?? 0,
     shadow: opts.shadow,
     castShadowFlags: opts.castShadowFlags ?? [],
     receiveShadowFlags: opts.receiveShadowFlags ?? [],
+    ...(opts.depthBiases ? { depthBiases: opts.depthBiases } : {}),
+    ...(opts.depthEpsilon ? { depthEpsilon: opts.depthEpsilon } : {}),
   };
 }

--- a/packages/glyphcss/src/api/types.ts
+++ b/packages/glyphcss/src/api/types.ts
@@ -50,4 +50,13 @@ export interface GlyphMeshTransform {
   castShadow?: boolean;
   /** This mesh receives (displays) shadows from castShadow meshes. Default false. */
   receiveShadow?: boolean;
+  /**
+   * Relative depth bias (0 = off). Nudges this mesh toward (positive) or away
+   * from (negative) the camera in the depth test via `pixelDepth *= 1 + depthBias`
+   * — resolving z-fighting against coplanar/coincident geometry. A CSS/DOM
+   * renderer decides coincident surfaces by stacking order for free; a
+   * projection-painted depth buffer fights, so a tiny bias (e.g. 0.002) lets a
+   * dynamic surface (a door/platform flush into a wall/floor) win cleanly.
+   */
+  depthBias?: number;
 }

--- a/packages/glyphcss/src/render/rasterize.ts
+++ b/packages/glyphcss/src/render/rasterize.ts
@@ -1,4 +1,5 @@
-import type { RasterizeContext } from "../api/rasterizeContext";
+import type { RasterizeContext, TemporalHistory } from "../api/rasterizeContext";
+import { createGlyphPerspectiveCamera } from "../api/createGlyphCamera";
 import type { Polygon, Vec3 } from "@glyphcss/core";
 import { getWireframeGlyphs } from "./ramps";
 
@@ -23,7 +24,8 @@ export function rasterize(scene: RasterizeContext): string {
   const { cols, rows, cellAspect } = grid;
 
   if (mode === "solid") {
-    return rasterizeSolid(scene, cols, rows, cellAspect);
+    const ss = scene.supersample && scene.supersample > 1 ? Math.floor(scene.supersample) : 1;
+    return rasterizeSolid(scene, cols, rows, cellAspect, ss);
   }
 
   // wireframe (and voxel falls through to wireframe for now)
@@ -47,11 +49,44 @@ export function rasterize(scene: RasterizeContext): string {
 /** Solid-mode: scan-fill polygons (fan-triangulated) with Lambert shading + depth buffer. */
 function rasterizeSolid(
   scene: RasterizeContext,
-  cols: number,
-  rows: number,
+  outCols: number,
+  outRows: number,
   cellAspect: number,
+  supersample: number,
 ): string {
-  const { camera, polygons, directionalLight, ambientLight, smoothShading, creaseAngle, castShadowFlags, receiveShadowFlags } = scene;
+  // Supersampled anti-aliasing: rasterize the geometry at `supersample`× the
+  // output grid resolution, then box-average every S×S block of subcells down
+  // to one output cell (glyph density + colour). This removes the motion crawl
+  // where a sub-cell-sized surface's per-cell winner flips frame-to-frame — the
+  // averaged cell changes smoothly instead of snapping to whatever won.
+  const cols = outCols * supersample;
+  const rows = outRows * supersample;
+  const { camera: rawCamera, polygons, directionalLight, ambientLight, smoothShading, creaseAngle, doubleSided, castShadowFlags, receiveShadowFlags } = scene;
+  const depthBiases = scene.depthBiases;
+  const depthEpsilon = scene.depthEpsilon ?? 0;
+  // Rendering into an S× larger grid would shrink the image to 1/S of the grid,
+  // because the projection's screen offset is in absolute cells (independent of
+  // grid size). Wrap `project` to scale the offset by S around the grid centre
+  // so the framing is identical at higher resolution — leaving depth and the
+  // near-clip (which depend on the camera's zoom) completely untouched.
+  // (Assumes the camera's projection centre is the grid centre, i.e. the default
+  // center=[0.5,0.5]; cssQuake uses the default.)
+  const camera = supersample > 1
+    ? {
+        zoom: rawCamera.zoom,
+        eyeDepth: (v: Vec3) => rawCamera.eyeDepth(v),
+        project: (v: Vec3, c: number, r: number, ca: number): [number, number, number, number?] => {
+          const p = rawCamera.project(v, c, r, ca);
+          // Scale only the screen OFFSET (cols 0, rows 1); the linear depth (2)
+          // and the perspective-correct zbuf (3) are resolution-independent and
+          // must pass through untouched. Dropping p[3] here previously forced the
+          // scan-fill onto the non-perspective cssZ depth under supersampling,
+          // silently disabling perspective-correct ordering (z-fight resolution)
+          // whenever SS was on.
+          return [c * 0.5 + (p[0] - c * 0.5) * supersample, r * 0.5 + (p[1] - r * 0.5) * supersample, p[2], p[3]];
+        },
+      }
+    : rawCamera;
   // Pick the solid ramp from the active palette so the glyph palette dropdown
   // affects solid mode too — not just wireframe.
   const ramp = getWireframeGlyphs(scene.glyphPalette).solid;
@@ -65,6 +100,10 @@ function rasterizeSolid(
   // viewer in our camera convention, so newer triangles win when their
   // depth is GREATER than the existing buffer entry.
   const depthBuf = new Float64Array(cols * rows).fill(-Infinity);
+  // World-position buffer for reprojection TAA — only allocated when temporal
+  // blending is on. NaN marks "no surface here" (empty cell).
+  const reproject = scene.temporalBlend > 0 && !!scene.temporalHistory;
+  const worldPosBuf: Float32Array | null = reproject ? new Float32Array(cols * rows * 3).fill(NaN) : null;
 
   // Normalize the light direction once.
   const ld = directionalLight.direction;
@@ -108,12 +147,35 @@ function rasterizeSolid(
   // Reused scratch for per-polygon projected vertices, so a fan re-uses each
   // projection instead of re-projecting v0/v2 once per triangle (a quad fan
   // would otherwise project 6 corners for 4 unique verts).
-  const projScratch: Vec3[] = [];
+  const projScratch: [number, number, number, number?][] = [];
   // Cross-frame shading cache (camera-invariant per-triangle intensities + lit
   // color). `triT` is a positional triangle index — incremented for every fan
   // triangle regardless of culling — so cache slots stay aligned frame to frame.
   const shadeCache = scene.shadeCache ?? null;
   let triT = -1;
+
+  // Build a per-triangle shadow context from three world-space vertices. Used
+  // for both whole triangles and near-clipped sub-triangles (whose vertices are
+  // interpolated and so need fresh light-space UVs). Returns null when shadows
+  // are off or the triangle's mesh doesn't receive them.
+  const makeShadowCtx = (wa: Vec3, wb: Vec3, wc: Vec3, receive: boolean): ScanFillShadowCtx | null => {
+    if (shadowMap === null || !receive) return null;
+    const sm = shadowMap;
+    const uvA = toLightUV(wa, sm.right[0], sm.right[1], sm.right[2], sm.up[0], sm.up[1], sm.up[2], sm.dir[0], sm.dir[1], sm.dir[2], sm.uMin, sm.uMax, sm.vMin, sm.vMax);
+    const uvB = toLightUV(wb, sm.right[0], sm.right[1], sm.right[2], sm.up[0], sm.up[1], sm.up[2], sm.dir[0], sm.dir[1], sm.dir[2], sm.uMin, sm.uMax, sm.vMin, sm.vMax);
+    const uvC = toLightUV(wc, sm.right[0], sm.right[1], sm.right[2], sm.up[0], sm.up[1], sm.up[2], sm.dir[0], sm.dir[1], sm.dir[2], sm.uMin, sm.uMax, sm.vMin, sm.vMax);
+    return {
+      map: sm,
+      luA: uvA[0], lvA: uvA[1], ldA: uvA[2],
+      luB: uvB[0], lvB: uvB[1], ldB: uvB[2],
+      luC: uvC[0], lvC: uvC[1], ldC: uvC[2],
+      lift: shadowLift,
+      opacity: shadowOpacity,
+      shadowColorRgb,
+      shadowColorHex,
+      litCache,
+    };
+  };
   for (let polyIdx = 0; polyIdx < polygons.length; polyIdx++) {
     const poly = polygons[polyIdx]!;
     const verts = poly.vertices;
@@ -134,16 +196,23 @@ function rasterizeSolid(
       const pa = projScratch[vi0]!;
       const pb = projScratch[vi1]!;
       const pc = projScratch[vi2]!;
-      // NaN-cull: any vertex behind the near plane → skip triangle.
-      if (pa[0] !== pa[0] || pb[0] !== pb[0] || pc[0] !== pc[0]) continue;
+      // A vertex behind the near plane projects to NaN. Count how many.
+      // 3 → wholly behind, skip. 0 → wholly visible, fast path. 1–2 → the
+      // triangle straddles the near plane and must be clipped (otherwise large
+      // surfaces like floors vanish the moment one corner passes the eye).
+      const nanCount =
+        (pa[0] !== pa[0] ? 1 : 0) + (pb[0] !== pb[0] ? 1 : 0) + (pc[0] !== pc[0] ? 1 : 0);
+      if (nanCount === 3) continue;
 
-      // Hoisted backface cull. `scanFillTriangle` already drops `area2 > 0`
-      // (back faces) — but only after we've paid for the face normal, Lambert
-      // shading, lit-color lookup and shadow context below. Doing the same test
-      // here on the already-projected verts skips all of that for back faces
-      // (≈half a closed mesh). Bit-identical output: the same triangles cull.
-      const area2 = (pb[0] - pa[0]) * (pc[1] - pa[1]) - (pb[1] - pa[1]) * (pc[0] - pa[0]);
-      if (area2 > 0) continue;
+      // Hoisted backface cull (fast path only — straddling triangles can't be
+      // culled on NaN-bearing projected verts; their sub-triangles are culled
+      // after clipping). `scanFillTriangle` also drops `area2 > 0`, but doing it
+      // here skips the face normal, Lambert shading and shadow context below for
+      // back faces (≈half a closed mesh).
+      if (nanCount === 0 && !doubleSided) {
+        const area2 = (pb[0] - pa[0]) * (pc[1] - pa[1]) - (pb[1] - pa[1]) * (pc[0] - pa[0]);
+        if (area2 > 0) continue;
+      }
 
       // Per-triangle shading — face normal → Lambert intensities → lit color —
       // is camera-invariant, so reuse it across frames via the optional
@@ -190,9 +259,18 @@ function rasterizeSolid(
         // the direction the light shines TOWARD. A surface is lit when its
         // outward normal points BACK toward the source, i.e. opposes `dir`.
         // lambert = max(0, -dot(n, dir))  — note the negation.
-        const lambertA = Math.max(0, -(nAx * lx + nAy * ly + nAz * lz));
-        const lambertB = Math.max(0, -(nBx * lx + nBy * ly + nBz * lz));
-        const lambertC = Math.max(0, -(nCx * lx + nCy * ly + nCz * lz));
+        //
+        // In double-sided mode use |dot| (two-sided lighting): a normal and its
+        // negation light identically, so both faces of a surface — and coplanar
+        // faces that z-fight at grazing angles — shade to the same colour, which
+        // makes the otherwise-flickering depth tie invisible. It stays camera-
+        // invariant, so the cross-frame shade cache is still valid.
+        const dotA = nAx * lx + nAy * ly + nAz * lz;
+        const dotB = nBx * lx + nBy * ly + nBz * lz;
+        const dotC = nCx * lx + nCy * ly + nCz * lz;
+        const lambertA = doubleSided ? Math.abs(dotA) : Math.max(0, -dotA);
+        const lambertB = doubleSided ? Math.abs(dotB) : Math.max(0, -dotB);
+        const lambertC = doubleSided ? Math.abs(dotC) : Math.max(0, -dotC);
         iA = Math.min(1, ambIntensity + lambertA * keyIntensity);
         iB = Math.min(1, ambIntensity + lambertB * keyIntensity);
         iC = Math.min(1, ambIntensity + lambertC * keyIntensity);
@@ -233,48 +311,245 @@ function rasterizeSolid(
         }
       }
 
-      // Build shadow context for this triangle if it belongs to a receiver mesh
-      // and the shadow map was successfully built.
       const receiveShadow = receiveShadowFlags[polyIdx] ?? false;
-      let sh: ScanFillShadowCtx | null = null;
-      if (shadowMap !== null && receiveShadow) {
-        const sm = shadowMap;
-        const uvA = toLightUV(v0, sm.right[0], sm.right[1], sm.right[2], sm.up[0], sm.up[1], sm.up[2], sm.dir[0], sm.dir[1], sm.dir[2], sm.uMin, sm.uMax, sm.vMin, sm.vMax);
-        const uvB = toLightUV(v1, sm.right[0], sm.right[1], sm.right[2], sm.up[0], sm.up[1], sm.up[2], sm.dir[0], sm.dir[1], sm.dir[2], sm.uMin, sm.uMax, sm.vMin, sm.vMax);
-        const uvC = toLightUV(v2, sm.right[0], sm.right[1], sm.right[2], sm.up[0], sm.up[1], sm.up[2], sm.dir[0], sm.dir[1], sm.dir[2], sm.uMin, sm.uMax, sm.vMin, sm.vMax);
-        sh = {
-          map: sm,
-          luA: uvA[0], lvA: uvA[1], ldA: uvA[2],
-          luB: uvB[0], lvB: uvB[1], ldB: uvB[2],
-          luC: uvC[0], lvC: uvC[1], ldC: uvC[2],
-          lift: shadowLift,
-          opacity: shadowOpacity,
-          shadowColorRgb,
-          shadowColorHex,
-          litCache,
-        };
-      }
+      // Per-mesh depth bias (z-fight resolution): scale the screen-linear depth so
+      // a biased mesh wins coincident/coplanar cells. Larger zbuf = nearer.
+      const biasScale = 1 + (depthBiases?.[polyIdx] ?? 0);
 
-      // Scan-fill the projected triangle. Depth and intensity are both
-      // interpolated per cell via barycentric coordinates so adjacent
-      // triangles on a curved surface never disagree at their shared edge.
-      scanFillTriangle(
-        pa[0], pa[1], pa[2], iA,
-        pb[0], pb[1], pb[2], iB,
-        pc[0], pc[1], pc[2], iC,
-        ramp, rampMax, litColor,
-        glyphBuf, colorBuf, depthBuf,
-        cols, rows,
-        sh,
-      );
+      if (nanCount === 0) {
+        // Fully visible: scan-fill the projected triangle directly. Depth and
+        // intensity are interpolated per cell via barycentric coordinates so
+        // adjacent triangles on a curved surface never disagree at their edge.
+        // Use the screen-space-linear z-buffer depth (4th element) so overlapping
+        // triangles are ordered perspective-correctly; ortho omits it → fall back
+        // to the linear depth, which is already screen-linear there.
+        scanFillTriangle(
+          pa[0], pa[1], (pa[3] ?? pa[2]) * biasScale, iA,
+          pb[0], pb[1], (pb[3] ?? pb[2]) * biasScale, iB,
+          pc[0], pc[1], (pc[3] ?? pc[2]) * biasScale, iC,
+          ramp, rampMax, litColor,
+          glyphBuf, colorBuf, depthBuf,
+          cols, rows,
+          makeShadowCtx(v0, v1, v2, receiveShadow),
+          doubleSided,
+          v0, v1, v2, worldPosBuf,
+          depthEpsilon,
+        );
+      } else {
+        // Straddles the near plane: clip the triangle to the visible half-space
+        // (`eyeDepth > 0`) and scan-fill the resulting sub-triangles. The face
+        // normal, colour and shading are unchanged by clipping; only positions
+        // and per-vertex intensities are interpolated at the crossings.
+        const cw: Vec3[] = [];
+        const ci: number[] = [];
+        const tri: Vec3[] = [v0, v1, v2];
+        const triI = [iA, iB, iC];
+        const d0 = camera.eyeDepth(v0);
+        const d1 = camera.eyeDepth(v1);
+        const d2 = camera.eyeDepth(v2);
+        const triD = [d0, d1, d2];
+        for (let e = 0; e < 3; e++) {
+          const n = (e + 1) % 3;
+          const de = triD[e]!;
+          const dn = triD[n]!;
+          if (de > 0) { cw.push(tri[e]!); ci.push(triI[e]!); }
+          if ((de > 0) !== (dn > 0)) {
+            const t = de / (de - dn);
+            const ve = tri[e]!, vn = tri[n]!;
+            cw.push([
+              ve[0] + t * (vn[0] - ve[0]),
+              ve[1] + t * (vn[1] - ve[1]),
+              ve[2] + t * (vn[2] - ve[2]),
+            ] as Vec3);
+            ci.push(triI[e]! + t * (triI[n]! - triI[e]!));
+          }
+        }
+        if (cw.length >= 3) {
+          const cp = cw.map((w) => camera.project(w, cols, rows, cellAspect));
+          for (let f = 1; f < cw.length - 1; f++) {
+            const qa = cp[0]!, qb = cp[f]!, qc = cp[f + 1]!;
+            const area2c = (qb[0] - qa[0]) * (qc[1] - qa[1]) - (qb[1] - qa[1]) * (qc[0] - qa[0]);
+            if (!doubleSided && area2c > 0) continue;
+            scanFillTriangle(
+              qa[0], qa[1], (qa[3] ?? qa[2]) * biasScale, ci[0]!,
+              qb[0], qb[1], (qb[3] ?? qb[2]) * biasScale, ci[f]!,
+              qc[0], qc[1], (qc[3] ?? qc[2]) * biasScale, ci[f + 1]!,
+              ramp, rampMax, litColor,
+              glyphBuf, colorBuf, depthBuf,
+              cols, rows,
+              makeShadowCtx(cw[0]!, cw[f]!, cw[f + 1]!, receiveShadow),
+              doubleSided,
+              cw[0]!, cw[f]!, cw[f + 1]!, worldPosBuf,
+              depthEpsilon,
+            );
+          }
+        }
+      }
     }
   }
 
   if (__detail) { (__detail.loop ??= []).push(performance.now() - __tLoop); }
   const __tStr = __detail ? performance.now() : 0;
-  const __out = solidBufToString(glyphBuf, colorBuf, cols, rows);
+  // Final output buffers at the OUTPUT resolution (downsampled if supersampling).
+  let finalGlyph = glyphBuf;
+  let finalColor = colorBuf;
+  let finalWorldPos: Float32Array | null = worldPosBuf;
+  if (supersample > 1) {
+    const ds = downsampleSolid(glyphBuf, colorBuf, depthBuf, worldPosBuf, outCols, outRows, supersample, ramp);
+    finalGlyph = ds.glyphBuf;
+    finalColor = ds.colorBuf;
+    finalWorldPos = ds.worldPos;
+  }
+  if (reproject) {
+    applyReprojectionTAA(finalGlyph, finalColor, finalWorldPos!, outCols, outRows, cellAspect, ramp, scene.temporalBlend, scene.temporalHistory!, rawCamera);
+  }
+  const out = solidBufToString(finalGlyph, finalColor, outCols, outRows);
   if (__detail) { (__detail.string ??= []).push(performance.now() - __tStr); }
-  return __out;
+  return out;
+}
+
+/**
+ * Reprojection temporal AA. The plain blend ghosts during motion because it
+ * mixes cells at fixed screen positions while the world scrolled underneath.
+ * Here we blend each cell with where its WORLD point was in the previous frame:
+ * project the cell's world position with the previous camera, sample the history
+ * there, and exponentially blend. A static surface keeps a coherent colour as it
+ * scrolls across the grid → the per-frame colour crawl disappears, without
+ * smearing (the history follows the surface, not the screen).
+ */
+function applyReprojectionTAA(
+  glyphBuf: string[],
+  colorBuf: (string | null)[] | null,
+  worldPos: Float32Array,
+  cols: number,
+  rows: number,
+  cellAspect: number,
+  ramp: string[],
+  blend: number,
+  H: TemporalHistory,
+  curCam: { rotX: number; rotY: number; target: Vec3; zoom: number; perspective: number; distance: number; stretch: number },
+): void {
+  const n = cols * rows;
+  const rampMax = ramp.length - 1;
+  const rampIndex = new Map<string, number>();
+  for (let i = 0; i < ramp.length; i++) rampIndex.set(ramp[i]!, i);
+
+  // (Re)allocate history on size change; no previous frame to reproject from yet.
+  let prevCam = H.cam;
+  if (H.cols !== cols || H.rows !== rows || H.idx.length !== n) {
+    H.cols = cols; H.rows = rows;
+    H.idx = new Float32Array(n); H.r = new Float32Array(n); H.g = new Float32Array(n); H.b = new Float32Array(n);
+    prevCam = null;
+  }
+
+  // Build a projector for the previous frame's camera to reproject world points.
+  let reproj: ((w: Vec3) => [number, number, number, number?]) | null = null;
+  if (prevCam) {
+    const pc = createGlyphPerspectiveCamera({
+      rotX: prevCam.rotX, rotY: prevCam.rotY, distance: prevCam.distance,
+      perspective: prevCam.perspective, zoom: prevCam.zoom, stretch: prevCam.stretch,
+    });
+    pc.target = prevCam.target;
+    reproj = (w: Vec3) => pc.project(w, cols, rows, cellAspect);
+  }
+
+  // Read current cell value, blend with the reprojected history, write back +
+  // store as new history. We write into temp arrays first so reprojection always
+  // samples the *previous* frame, never this frame's already-blended cells.
+  const nIdx = new Float32Array(n), nR = new Float32Array(n), nG = new Float32Array(n), nB = new Float32Array(n);
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const i = row * cols + col;
+      const idxNow = rampIndex.get(glyphBuf[i]!) ?? 0;
+      let rNow = 0, gNow = 0, bNow = 0;
+      const c = colorBuf ? colorBuf[i] : null;
+      if (c) { const rgb = hexToRgb(c); rNow = rgb[0]; gNow = rgb[1]; bNow = rgb[2]; }
+
+      let b = 0; // effective history weight (0 when no valid reprojection)
+      let hIdx = 0, hR = 0, hG = 0, hB = 0;
+      const wx = worldPos[i * 3]!;
+      if (reproj && wx === wx) { // wx===wx → not NaN (cell has a surface)
+        const p = reproj([wx, worldPos[i * 3 + 1]!, worldPos[i * 3 + 2]!]);
+        const pcCol = Math.round(p[0]), pcRow = Math.round(p[1]);
+        if (p[0] === p[0] && pcCol >= 0 && pcCol < cols && pcRow >= 0 && pcRow < rows) {
+          const j = pcRow * cols + pcCol;
+          hIdx = H.idx[j]!; hR = H.r[j]!; hG = H.g[j]!; hB = H.b[j]!;
+          b = blend;
+        }
+      }
+      const cur = 1 - b;
+      const bi = cur * idxNow + b * hIdx;
+      const br = cur * rNow + b * hR;
+      const bg = cur * gNow + b * hG;
+      const bb = cur * bNow + b * hB;
+      nIdx[i] = bi; nR[i] = br; nG[i] = bg; nB[i] = bb;
+      let gi = Math.round(bi);
+      if (gi < 0) gi = 0; else if (gi > rampMax) gi = rampMax;
+      glyphBuf[i] = ramp[gi]!;
+      if (colorBuf) colorBuf[i] = gi === 0 ? null : `#${toHex2(br)}${toHex2(bg)}${toHex2(bb)}`;
+    }
+  }
+  H.idx = nIdx; H.r = nR; H.g = nG; H.b = nB;
+  H.cam = {
+    rotX: curCam.rotX, rotY: curCam.rotY,
+    target: [curCam.target[0]!, curCam.target[1]!, curCam.target[2]!],
+    zoom: curCam.zoom, perspective: curCam.perspective, distance: curCam.distance, stretch: curCam.stretch,
+  };
+}
+
+/**
+ * Box-downsample the S×-oversampled glyph + colour buffers to the output grid.
+ * For each output cell: average the ramp index over all S² subcells (empty
+ * subcells count as 0 → partial coverage dims the cell, anti-aliasing edges),
+ * and average the RGB of the covered subcells. The result is a single glyph +
+ * colour per output cell whose value moves continuously as geometry shifts,
+ * instead of snapping to a single sub-cell winner.
+ */
+function downsampleSolid(
+  glyphBuf: string[],
+  colorBuf: (string | null)[] | null,
+  depthBuf: Float64Array,
+  worldPosIn: Float32Array | null,
+  outCols: number,
+  outRows: number,
+  S: number,
+  ramp: string[],
+): { glyphBuf: string[]; colorBuf: (string | null)[] | null; worldPos: Float32Array | null } {
+  const rampIndex = new Map<string, number>();
+  for (let i = 0; i < ramp.length; i++) rampIndex.set(ramp[i]!, i);
+  const rampMax = ramp.length - 1;
+  const inCols = outCols * S;
+  const og: string[] = new Array(outCols * outRows).fill(" ");
+  const oc: (string | null)[] | null = colorBuf ? new Array(outCols * outRows).fill(null) : null;
+  const ow: Float32Array | null = worldPosIn ? new Float32Array(outCols * outRows * 3).fill(NaN) : null;
+  const inv = 1 / (S * S);
+  for (let oy = 0; oy < outRows; oy++) {
+    for (let ox = 0; ox < outCols; ox++) {
+      let idxSum = 0, cov = 0, r = 0, g = 0, b = 0, wx = 0, wy = 0, wz = 0;
+      for (let sy = 0; sy < S; sy++) {
+        const base = (oy * S + sy) * inCols + ox * S;
+        for (let sx = 0; sx < S; sx++) {
+          const si = base + sx;
+          // Coverage comes from the depth buffer, not the glyph: `ramp[0]` is a
+          // space, so a covered-but-dim subcell looks identical to an empty one
+          // in `glyphBuf`. Using depth keeps dim surfaces (and their colour).
+          if (depthBuf[si] === -Infinity) continue;
+          idxSum += rampIndex.get(glyphBuf[si]!) ?? 0;
+          cov++;
+          if (oc) { const c = colorBuf![si]; if (c) { const rgb = hexToRgb(c); r += rgb[0]; g += rgb[1]; b += rgb[2]; } }
+          if (ow) { wx += worldPosIn![si * 3]!; wy += worldPosIn![si * 3 + 1]!; wz += worldPosIn![si * 3 + 2]!; }
+        }
+      }
+      const oi = oy * outCols + ox;
+      if (cov === 0) continue; // stays space
+      let gi = Math.round(idxSum * inv); // coverage-weighted intensity (empty subcells = 0)
+      if (gi < 0) gi = 0; else if (gi > rampMax) gi = rampMax;
+      og[oi] = ramp[gi]!;
+      if (oc) oc[oi] = `#${toHex2(r / cov)}${toHex2(g / cov)}${toHex2(b / cov)}`;
+      if (ow) { ow[oi * 3] = wx / cov; ow[oi * 3 + 1] = wy / cov; ow[oi * 3 + 2] = wz / cov; }
+    }
+  }
+  return { glyphBuf: og, colorBuf: oc, worldPos: ow };
 }
 
 /**
@@ -484,6 +759,15 @@ function scanFillTriangle(
   cols: number,
   rows: number,
   sh: ScanFillShadowCtx | null,
+  doubleSided: boolean,
+  // World-space triangle verts + output buffer for per-cell world position
+  // (used by reprojection TAA). `worldPosBuf` is null when not needed.
+  wv0: Vec3, wv1: Vec3, wv2: Vec3,
+  worldPosBuf: Float32Array | null,
+  // Relative depth-test deadband (0 = exact). A new triangle replaces the
+  // current cell only when nearer by more than this fraction; near-coplanar
+  // surfaces keep a stable winner instead of z-fighting frame to frame.
+  depthEpsilon: number,
 ): void {
   // Signed 2× area. Sign tells us screen-space winding.
   const area2 = (bx - ax) * (cy - ay) - (by - ay) * (cx - ax);
@@ -494,7 +778,7 @@ function scanFillTriangle(
   // triangles produce `area2 < 0`. Drop back faces. The asciss-derived
   // rotateVec3 also swaps the X/Y input axes, which contributes to the
   // orientation flip.
-  if (area2 > 0) return;
+  if (!doubleSided && area2 > 0) return;
   const invArea2 = 1 / area2;
   const ccw = area2 > 0;
 
@@ -524,8 +808,24 @@ function scanFillTriangle(
       // Per-pixel depth via barycentric interpolation.
       const pixelDepth = (wA * az + wB * bz + wC * cz) * invArea2;
       const idx = row * cols + col;
-      if (pixelDepth > depthBuf[idx]!) {
+      const prevDepth = depthBuf[idx]!;
+      // Depth-test deadband, biased toward DRAW ORDER to mirror a CSS/DOM
+      // renderer. A later triangle wins even when slightly BEHIND the current
+      // one — within a relative epsilon — so near-coplanar surfaces (overlapping
+      // brushes, decals, a translucent plane over its backing face) resolve by
+      // paint order (last drawn on top), exactly as polycss does via DOM
+      // stacking, instead of z-fighting per-cell as the camera moves. Only the
+      // perspective zbuf (>0) gets the deadband; the empty cell (−Infinity) and
+      // ortho (≤0) fall through to the plain `>` test.
+      if (pixelDepth > (prevDepth > 0 ? prevDepth * (1 - depthEpsilon) : prevDepth)) {
         depthBuf[idx] = pixelDepth;
+        if (worldPosBuf !== null) {
+          // Per-cell world position (barycentric) for reprojection TAA.
+          const o = idx * 3;
+          worldPosBuf[o] = (wA * wv0[0]! + wB * wv1[0]! + wC * wv2[0]!) * invArea2;
+          worldPosBuf[o + 1] = (wA * wv0[1]! + wB * wv1[1]! + wC * wv2[1]!) * invArea2;
+          worldPosBuf[o + 2] = (wA * wv0[2]! + wB * wv1[2]! + wC * wv2[2]!) * invArea2;
+        }
         // Per-pixel intensity → per-pixel glyph. Two things happen here:
         //   1. Smooth shading: adjacent triangles' shared edge has the same
         //      interpolated intensity on both sides, so the glyph transition


### PR DESCRIPTION
Perspective FPV projection (`P/(P-cssZ)`) with near-plane clipping + fovScale; perspective-correct depth (`zbuf`); `doubleSided` two-sided Lambert for single-sided BSP faces; `supersample` AA, `temporalBlend` reprojection TAA, per-mesh `depthBias`, global `depthEpsilon` deadband. All additive — defaults preserve prior output. 1321 tests pass, build green.