### PR TITLE
ci(release): fix publish workflow for protected main + reconcile to 0.0.5

### DIFF
--- a/.github/scripts/bump-versions.mjs
+++ b/.github/scripts/bump-versions.mjs
@@ -18,7 +18,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // __dirname is .github/scripts — repo root is two levels up.
 const root = resolve(__dirname, "..", "..");
-const packages = ["core", "glyphcss", "react", "vue"].map((d) =>
+const packages = ["core", "glyphcss", "react", "vue", "fonts"].map((d) =>
   resolve(root, "packages", d, "package.json"),
 );
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,20 +1,17 @@
 name: Publish packages
 
-# Manual-only. Bumps every package under `packages/*` in lockstep (using
-# scripts/bump-versions.mjs), builds them, publishes to npm, then commits
-# the version change and pushes a `v<X.Y.Z>` tag back to main.
+# Manual. Publishes whatever version is currently on `main` (already merged via a
+# normal version-bump PR) to npm, then pushes the matching `v<X.Y.Z>` git tag.
+#
+# It deliberately does NOT write to `main`: `main` is a protected branch and the
+# workflow's GITHUB_TOKEN can't satisfy the required PR + status-check gate.
+# Bump the versions first in a regular PR (run `node .github/scripts/bump-versions.mjs
+# <patch|minor|major>`, open a PR, let CI pass, merge), then run this workflow.
+#
+# Re-running is safe: `pnpm -r publish` skips any package whose version is already
+# on the registry, and the tag step is a no-op if the tag already exists.
 on:
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: "Version bump"
-        required: true
-        default: "patch"
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -31,6 +28,7 @@ jobs:
       - name: Check out
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -49,12 +47,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Read version
+        id: version
+        run: echo "version=$(node -p "require('./packages/glyphcss/package.json').version")" >> "$GITHUB_OUTPUT"
+
       - name: Run tests
         run: pnpm test
-
-      - name: Bump versions
-        id: bump
-        run: node .github/scripts/bump-versions.mjs "${{ inputs.bump }}"
 
       - name: Build packages
         run: pnpm build:packages
@@ -64,14 +62,17 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Commit, tag, and push
+      - name: Tag the release
         env:
           ACTOR: ${{ github.actor }}
           ACTOR_ID: ${{ github.actor_id }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
+          if git ls-remote --tags origin "refs/tags/v${VERSION}" | grep -q .; then
+            echo "Tag v${VERSION} already exists on origin — skipping."
+            exit 0
+          fi
           git config user.name "$ACTOR"
           git config user.email "${ACTOR_ID}+${ACTOR}@users.noreply.github.com"
-          git add packages/*/package.json
-          git commit -m "chore(release): v${NEXT_VERSION}"
-          git tag "v${NEXT_VERSION}"
-          git push origin HEAD:main "v${NEXT_VERSION}"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glyphcss/core",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pure math engine for ASCII polygon mesh rendering. Zero browser globals.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glyphcss/fonts",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "description": "Turn fonts + text into extruded 3D polygon meshes for glyphcss. Framework-agnostic — returns Polygon[].",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/glyphcss/package.json
+++ b/packages/glyphcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glyphcss",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Glyphcss — ASCII paint backend with glyphcss's scene-composition API. Renders 3D meshes as ASCII art in a <pre> element.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glyphcss/react",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "React components for the glyphcss ASCII polygon mesh rendering engine",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glyphcss/vue",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Native Vue 3 components for the glyphcss ASCII polygon mesh rendering engine.",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
Fixes the failed **Publish packages** run and the half-released state it left behind.

## Why the deploy failed
The publish workflow published to npm successfully, then tried to push the version-bump commit **directly to `main`** — rejected by branch protection (`require PR` + required `test-and-build` check). Result: npm went to `0.0.5` but the repo stayed at `0.0.4`, and a dangling `v0.0.5` tag was pushed to a commit that isn't on `main`.

## Changes
- **Decoupled publish from the version bump.** `publish-packages.yml` no longer writes to `main` (it can't — `GITHUB_TOKEN` can't satisfy the protected-branch gate, and bot-created PRs don't trigger the required CI check). It now: test → build → `pnpm -r publish` (skips already-published versions) → push the `vX.Y.Z` **tag** only. Bumps land via a normal PR (like this one) first.
- **`bump-versions.mjs` now includes `@glyphcss/fonts`** — it was missing, which is why fonts never got versioned/published.
- **Reconciled all packages to `0.0.5`** so the repo matches npm. (`@glyphcss/fonts` 0.0.1 → 0.0.5 to join the lockstep; it's still unpublished, so the next publish run will ship `@glyphcss/fonts@0.0.5` and skip the already-published four.)

## Release process from now on
1. `node .github/scripts/bump-versions.mjs <patch|minor|major>` → open a PR → CI passes → merge.
2. Run the **Publish packages** workflow → publishes the current `main` version + pushes the tag.
