### PR TITLE
fix(gallery): copied code renders at the gallery's resolution (autoSize + cell font-size)

### DIFF
--- a/website/src/components/GalleryWorkbench/CodePanel.tsx
+++ b/website/src/components/GalleryWorkbench/CodePanel.tsx
@@ -115,8 +115,8 @@ export function App() {
     ${cameraOpenTag}
       <GlyphScene
         mode="${mode}"
-        cols={100}
-        rows={30}
+        autoSize
+        style={{ width: "100%", height: "100%", fontSize: 13 }}
         glyphPalette="${palette}"
         useColors={${useColors}}
         autoCenter={${autoCenter}}
@@ -146,8 +146,8 @@ export function App() {
   ${cameraOpenTagVue}
     <GlyphScene
       mode="${mode}"
-      :cols="100"
-      :rows="30"
+      auto-size
+      :style="{ width: '100%', height: '100%', fontSize: '13px' }"
       glyphPalette="${palette}"
       :use-colors="${useColors}"
       :auto-center="${autoCenter}"
@@ -199,14 +199,15 @@ scene.add(polygons);`;
 } from "glyphcss";${polygonsImportV}
 
 const host = document.querySelector<HTMLElement>("#scene")!;
+// Cell font-size sets the ASCII resolution; autoSize fills the host's box.
+host.style.fontSize = "13px";
 
 const camera = ${createCameraCall};${targetV}
 
 const scene = createGlyphScene(host, {
   camera,
   mode: "${mode}",
-  cols: 100,
-  rows: 30,
+  autoSize: true,
   glyphPalette: "${palette}",
   useColors: ${useColors},
   autoCenter: ${autoCenter},
@@ -238,13 +239,16 @@ createGlyphOrbitControls(scene, { drag: true, wheel: true });`;
 <html>
   <head>
     <script type="module" src="https://esm.sh/glyphcss/elements"></script>
+    <style>
+      /* Cell font-size sets the ASCII resolution; auto-size fills the box. */
+      glyph-scene { display: block; width: 100%; height: 100vh; font-size: 13px; }
+    </style>
   </head>
   <body>
     ${cameraOpenHtml}
       <glyph-scene
         mode="${mode}"
-        cols="100"
-        rows="30"
+        auto-size
         glyph-palette="${palette}"
         use-colors="${useColors}"
         auto-center="${autoCenter}"


### PR DESCRIPTION
Copying the generated code from the gallery rendered at a much lower resolution than the gallery itself.

## Cause
The generated snippets hardcoded a coarse fixed grid — `cols: 100, rows: 30` — while the gallery renders with **`autoSize`** (it fills the container at a small cell font, e.g. **163×56** at a desktop width). Worse, the snippet still emitted the *fitted* `zoom` (≈40), which was computed for the 163×56 grid — so in a 100×30 grid the model was both **clipped and low-res**.

## Fix
All four templates (React / Vue / Vanilla / HTML) now emit:
- **`autoSize`** instead of `cols/rows` — the scene fills its host like the gallery does.
- The **cell font-size (`13px`)** + host sizing — this is the actual resolution knob (cells = host ÷ cell size). Matches the gallery's density.
- (zoom was already the correct fitted value.)

## Verified
With `autoSize` + `13px` cells in a 1280px host the grid comes out **163×55** (cellAspect 1.66) — identical to the live gallery's 163×56. So a copied snippet now reproduces the gallery's resolution and framing.
