### PR TITLE
feat(website): add Google Analytics across docs + custom pages

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -44,6 +44,12 @@ export default defineConfig({
     starlight({
       title: 'glyphcss',
       description: 'An ASCII polygon mesh engine. DOM-native 3D rendering in a character grid.',
+      head: [
+        // Google Analytics (gtag.js) — covers all Starlight docs pages; custom
+        // pages render the same tag via src/components/Analytics.astro.
+        { tag: 'script', attrs: { async: true, src: 'https://www.googletagmanager.com/gtag/js?id=G-PHHY1R5B58' } },
+        { tag: 'script', content: "window.dataLayer = window.dataLayer || [];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js', new Date());\ngtag('config', 'G-PHHY1R5B58');" },
+      ],
       components: {
         Header: './src/components/DocsHeader.astro',
         ThemeSelect: './src/components/EmptyThemeSelect.astro',

--- a/website/src/components/Analytics.astro
+++ b/website/src/components/Analytics.astro
@@ -1,0 +1,13 @@
+---
+// Google Analytics (gtag.js). Rendered in the <head> of the custom Astro pages
+// (index / gallery / wordart / examples). Starlight docs pages get the same tag
+// via the `head` config in astro.config.mjs, so every page is covered.
+const GA_ID = 'G-PHHY1R5B58';
+---
+<script async is:inline src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}></script>
+<script is:inline define:vars={{ GA_ID }}>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+  gtag('js', new Date());
+  gtag('config', GA_ID);
+</script>

--- a/website/src/pages/examples/flatmap.astro
+++ b/website/src/pages/examples/flatmap.astro
@@ -1,12 +1,14 @@
 ---
 import ExamplesSidebar from "../../components/ExamplesSidebar.astro";
 import DocsHeader from "../../components/DocsHeader.astro";
+import Analytics from "../../components/Analytics.astro";
 const title = "glyphcss · ASCII Iso World Map";
 ---
 
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <Analytics />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{title}</title>
   <style>

--- a/website/src/pages/examples/image.astro
+++ b/website/src/pages/examples/image.astro
@@ -1,12 +1,14 @@
 ---
 import ExamplesSidebar from "../../components/ExamplesSidebar.astro";
 import DocsHeader from "../../components/DocsHeader.astro";
+import Analytics from "../../components/Analytics.astro";
 const title = "glyphcss · Image → Glyph";
 ---
 
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <Analytics />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{title}</title>
   <style>

--- a/website/src/pages/examples/world.astro
+++ b/website/src/pages/examples/world.astro
@@ -1,6 +1,7 @@
 ---
 import ExamplesSidebar from "../../components/ExamplesSidebar.astro";
 import DocsHeader from "../../components/DocsHeader.astro";
+import Analytics from "../../components/Analytics.astro";
 const title = "glyphcss · ASCII Earth";
 const description = "ETOPO1 global topography rasterised into ASCII. Isometric, drag to orbit.";
 ---
@@ -8,6 +9,7 @@ const description = "ETOPO1 global topography rasterised into ASCII. Isometric, 
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <Analytics />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{title}</title>
   <meta name="description" content={description} />

--- a/website/src/pages/gallery.astro
+++ b/website/src/pages/gallery.astro
@@ -1,11 +1,13 @@
 ---
 import GalleryWorkbench from '../components/GalleryWorkbench/GalleryWorkbench.tsx';
 import DocsHeader from '../components/DocsHeader.astro';
+import Analytics from '../components/Analytics.astro';
 import '../styles/glyph-demo.css';
 ---
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <Analytics />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gallery</title>
   </head>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -13,6 +13,7 @@ hljs.registerLanguage("vue", xml);
 import DocsHeader from "../components/DocsHeader.astro";
 import GlyphDemo from "../components/GlyphDemo.astro";
 import AsciiArt from "../components/AsciiArt.astro";
+import Analytics from "../components/Analytics.astro";
 
 function highlight(code: string, lang: string): string {
   return hljs.highlight(code, { language: lang }).value;
@@ -104,6 +105,7 @@ const ldJson = {
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <Analytics />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{title}</title>
   <meta name="description" content={description} />

--- a/website/src/pages/wordart.astro
+++ b/website/src/pages/wordart.astro
@@ -1,6 +1,7 @@
 ---
 import { WordArtWorkbench } from '../components/WordArtWorkbench';
 import DocsHeader from '../components/DocsHeader.astro';
+import Analytics from '../components/Analytics.astro';
 
 const title = 'WordArt — 3D ASCII text from any font | glyphcss';
 const description = 'Extrude any Google font into 3D text — gradients, block textures, bevels, warps — rasterised to ASCII in a single <pre>. Powered by glyphcss + @glyphcss/fonts.';
@@ -8,6 +9,7 @@ const description = 'Extrude any Google font into 3D text — gradients, block t
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <Analytics />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title}</title>
     <meta name="description" content={description} />


### PR DESCRIPTION
Adds Google Analytics (gtag.js, `G-PHHY1R5B58`), mirroring the voxcss setup.

Two insertion points, because Starlight only controls the `<head>` of its own docs pages:
- **Docs pages** — gtag tags added to Starlight's `head:` config in `astro.config.mjs`.
- **Custom Astro pages** (landing / gallery / wordart / examples) — a new `src/components/Analytics.astro` (`is:inline` + `define:vars`) rendered in each page's `<head>`.

## Verified (build output)
The tag renders exactly once on **every** page — confirmed in `dist/`:
- Custom: `index`, `gallery`, `wordart`, `examples/{world,flatmap,image}`
- Docs: `introduction`, `quickstart`, `core-concepts`, `components/*`, `guides/*`, `api/*`, `404`

Both the loader (`gtag/js?id=G-PHHY1R5B58`) and the inline `gtag('config', …)` are present, with `define:vars` correctly injecting `GA_ID = "G-PHHY1R5B58"`.
