### PR TITLE
fix(gallery): autoCenter parity + React/Vue src loading (copied code centers the model)

### DIFF
--- a/examples/react/solid-mesh/main.tsx
+++ b/examples/react/solid-mesh/main.tsx
@@ -1,51 +1,19 @@
 import { createRoot } from "react-dom/client";
-import { useState, useEffect } from "react";
 import {
   GlyphPerspectiveCamera,
   GlyphScene,
   GlyphOrbitControls,
   GlyphMesh,
-  loadMesh,
 } from "@glyphcss/react";
-import { computeSceneBbox } from "@glyphcss/react";
-import type { Polygon, Vec3 } from "@glyphcss/react";
 
-const GLB_URL = "/apple.glb";
-
-/** Center and scale polygons to fit a 2-unit bounding box at origin. */
-function fitToUnitBbox(polygons: Polygon[]): Polygon[] {
-  const bbox = computeSceneBbox(polygons);
-  const cx = (bbox.min[0] + bbox.max[0]) / 2;
-  const cy = (bbox.min[1] + bbox.max[1]) / 2;
-  const cz = (bbox.min[2] + bbox.max[2]) / 2;
-  const size = Math.max(
-    bbox.max[0] - bbox.min[0],
-    bbox.max[1] - bbox.min[1],
-    bbox.max[2] - bbox.min[2],
-  ) || 1;
-  const k = 2 / size;
-  return polygons.map((p) => ({
-    ...p,
-    vertices: p.vertices.map((v): Vec3 => [
-      (v[0] - cx) * k,
-      (v[1] - cy) * k,
-      (v[2] - cz) * k,
-    ]),
-  }));
-}
-
+// `src` fetches + parses the mesh; `autoCenter` recenters it to the origin so it
+// pivots around its own center. No manual loadMesh / recenter boilerplate.
 function App() {
-  const [polygons, setPolygons] = useState<Polygon[] | undefined>();
-
-  useEffect(() => {
-    loadMesh(GLB_URL).then((result) => setPolygons(fitToUnitBbox(result.polygons)));
-  }, []);
-
   return (
-    <GlyphPerspectiveCamera rotX={0.5} rotY={0.4} zoom={0.35} distance={100} style={{ width: "100%", height: "100vh" }}>
+    <GlyphPerspectiveCamera rotX={25} rotY={25} zoom={0.35} distance={100} style={{ width: "100%", height: "100vh" }}>
       <GlyphScene autoSize>
         <GlyphOrbitControls drag wheel />
-        {polygons && <GlyphMesh polygons={polygons} />}
+        <GlyphMesh src="/apple.glb" autoCenter />
       </GlyphScene>
     </GlyphPerspectiveCamera>
   );

--- a/examples/vue/solid-mesh/App.vue
+++ b/examples/vue/solid-mesh/App.vue
@@ -1,55 +1,21 @@
 <template>
-  <GlyphPerspectiveCamera :rot-x="0.5" :rot-y="0.4" :zoom="0.35" :distance="100" style="width:100%;height:100vh">
+  <GlyphPerspectiveCamera :rot-x="25" :rot-y="25" :zoom="0.35" :distance="100" style="width:100%;height:100vh">
     <GlyphScene :auto-size="true">
       <GlyphOrbitControls :drag="true" :wheel="true" />
-      <GlyphMesh v-if="polygons" :polygons="polygons" />
+      <!-- `src` fetches + parses the mesh; `auto-center` recenters it to its
+           own center. No manual loadMesh / recenter boilerplate. -->
+      <GlyphMesh src="/apple.glb" auto-center />
     </GlyphScene>
   </GlyphPerspectiveCamera>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
 import {
   GlyphPerspectiveCamera,
   GlyphScene,
   GlyphOrbitControls,
   GlyphMesh,
-  loadMesh,
 } from "@glyphcss/vue";
-import { computeSceneBbox } from "@glyphcss/vue";
-import type { Polygon, Vec3 } from "@glyphcss/vue";
-
-const GLB_URL = "/apple.glb";
-
-/** Center and scale polygons to fit a 2-unit bounding box at origin. */
-function fitToUnitBbox(polys: Polygon[]): Polygon[] {
-  const bbox = computeSceneBbox(polys);
-  const cx = (bbox.min[0] + bbox.max[0]) / 2;
-  const cy = (bbox.min[1] + bbox.max[1]) / 2;
-  const cz = (bbox.min[2] + bbox.max[2]) / 2;
-  const size = Math.max(
-    bbox.max[0] - bbox.min[0],
-    bbox.max[1] - bbox.min[1],
-    bbox.max[2] - bbox.min[2],
-  ) || 1;
-  const k = 2 / size;
-  return polys.map((p) => ({
-    ...p,
-    vertices: p.vertices.map((v): Vec3 => [
-      (v[0] - cx) * k,
-      (v[1] - cy) * k,
-      (v[2] - cz) * k,
-    ]),
-  }));
-}
-
-const polygons = ref<Polygon[] | undefined>();
-
-onMounted(() => {
-  loadMesh(GLB_URL).then((result) => {
-    polygons.value = fitToUnitBbox(result.polygons);
-  });
-});
 </script>
 
 <style>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export { DEFAULT_PROJECTION } from "./types";
 export {
   buildSceneContext,
   computeSceneBbox,
+  fitPolygonsToUnitBbox,
   normalizePolygons,
 } from "./scene/context";
 export type {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,7 +21,7 @@ export { DEFAULT_PROJECTION } from "./types";
 export {
   buildSceneContext,
   computeSceneBbox,
-  fitPolygonsToUnitBbox,
+  recenterPolygons,
   normalizePolygons,
 } from "./scene/context";
 export type {

--- a/packages/core/src/scene/context.ts
+++ b/packages/core/src/scene/context.ts
@@ -78,6 +78,34 @@ export function computeSceneBbox(polygons: Polygon[]): SceneBbox {
   };
 }
 
+/**
+ * Center and uniformly scale polygons to fit a 2-unit bounding box at the
+ * origin (max dimension → 2, bbox center → [0,0,0]). Used by `normalize` on
+ * meshes so a loaded model pivots around its own center at a predictable size,
+ * regardless of the authored origin/units.
+ */
+export function fitPolygonsToUnitBbox(polygons: Polygon[]): Polygon[] {
+  if (!polygons || polygons.length === 0) return polygons;
+  const bbox = computeSceneBbox(polygons);
+  const cx = (bbox.min[0] + bbox.max[0]) / 2;
+  const cy = (bbox.min[1] + bbox.max[1]) / 2;
+  const cz = (bbox.min[2] + bbox.max[2]) / 2;
+  const size = Math.max(
+    bbox.max[0] - bbox.min[0],
+    bbox.max[1] - bbox.min[1],
+    bbox.max[2] - bbox.min[2],
+  ) || 1;
+  const k = 2 / size;
+  return polygons.map((p) => ({
+    ...p,
+    vertices: p.vertices.map((v): Vec3 => [
+      (v[0] - cx) * k,
+      (v[1] - cy) * k,
+      (v[2] - cz) * k,
+    ]),
+  }));
+}
+
 export function buildSceneContext(args: SceneContextBuildArgs): SceneContextBuildResult {
   const input = args.polygons ?? [];
   let polygons: Polygon[];

--- a/packages/core/src/scene/context.ts
+++ b/packages/core/src/scene/context.ts
@@ -79,30 +79,20 @@ export function computeSceneBbox(polygons: Polygon[]): SceneBbox {
 }
 
 /**
- * Center and uniformly scale polygons to fit a 2-unit bounding box at the
- * origin (max dimension → 2, bbox center → [0,0,0]). Used by `normalize` on
- * meshes so a loaded model pivots around its own center at a predictable size,
- * regardless of the authored origin/units.
+ * Recenter polygons so their bounding-box center sits at the origin — center
+ * only, no scaling (matches voxcss `recenterPolygons` / `autoCenter`). A loaded
+ * mesh then pivots around its own center; the camera's fit/zoom handles size.
  */
-export function fitPolygonsToUnitBbox(polygons: Polygon[]): Polygon[] {
+export function recenterPolygons(polygons: Polygon[]): Polygon[] {
   if (!polygons || polygons.length === 0) return polygons;
   const bbox = computeSceneBbox(polygons);
   const cx = (bbox.min[0] + bbox.max[0]) / 2;
   const cy = (bbox.min[1] + bbox.max[1]) / 2;
   const cz = (bbox.min[2] + bbox.max[2]) / 2;
-  const size = Math.max(
-    bbox.max[0] - bbox.min[0],
-    bbox.max[1] - bbox.min[1],
-    bbox.max[2] - bbox.min[2],
-  ) || 1;
-  const k = 2 / size;
+  if (cx === 0 && cy === 0 && cz === 0) return polygons;
   return polygons.map((p) => ({
     ...p,
-    vertices: p.vertices.map((v): Vec3 => [
-      (v[0] - cx) * k,
-      (v[1] - cy) * k,
-      (v[2] - cz) * k,
-    ]),
+    vertices: p.vertices.map((v): Vec3 => [v[0] - cx, v[1] - cy, v[2] - cz]),
   }));
 }
 

--- a/packages/glyphcss/src/elements/GlyphMeshElement.ts
+++ b/packages/glyphcss/src/elements/GlyphMeshElement.ts
@@ -7,7 +7,7 @@
  *
  * On disconnect: disposes the registered mesh handle.
  */
-import { loadMesh, resolveGeometry, fitPolygonsToUnitBbox } from "@glyphcss/core";
+import { loadMesh, resolveGeometry, recenterPolygons } from "@glyphcss/core";
 import type { Vec3, GlyphGeometryName } from "@glyphcss/core";
 import type { GlyphMeshHandle, GlyphSceneHandle } from "../api/createGlyphScene";
 import type { GlyphMeshTransform } from "../api/types";
@@ -18,7 +18,7 @@ const ELEMENT_BASE: typeof HTMLElement =
     ? HTMLElement
     : (class {} as unknown as typeof HTMLElement);
 
-const OBSERVED_ATTRS = ["src", "geometry", "size", "color", "position", "scale", "rotation", "normalize", "cast-shadow", "receive-shadow"] as const;
+const OBSERVED_ATTRS = ["src", "geometry", "size", "color", "position", "scale", "rotation", "auto-center", "cast-shadow", "receive-shadow"] as const;
 
 
 function parseVec3(value: string | null): Vec3 | undefined {
@@ -136,8 +136,8 @@ export class GlyphMeshElement extends ELEMENT_BASE {
         return;
       }
 
-      const shouldNormalize = this.hasAttribute("normalize");
-      const polygons = shouldNormalize ? fitPolygonsToUnitBbox(parsed.polygons) : parsed.polygons;
+      const shouldCenter = this.hasAttribute("auto-center");
+      const polygons = shouldCenter ? recenterPolygons(parsed.polygons) : parsed.polygons;
       this._handle = scene.add(polygons, this._readTransform());
       this.dispatchEvent(new CustomEvent("glyphcss:loaded", { detail: { polygons }, bubbles: true }));
       return;

--- a/packages/glyphcss/src/elements/GlyphMeshElement.ts
+++ b/packages/glyphcss/src/elements/GlyphMeshElement.ts
@@ -7,8 +7,8 @@
  *
  * On disconnect: disposes the registered mesh handle.
  */
-import { loadMesh, resolveGeometry, computeSceneBbox } from "@glyphcss/core";
-import type { Vec3, GlyphGeometryName, Polygon } from "@glyphcss/core";
+import { loadMesh, resolveGeometry, fitPolygonsToUnitBbox } from "@glyphcss/core";
+import type { Vec3, GlyphGeometryName } from "@glyphcss/core";
 import type { GlyphMeshHandle, GlyphSceneHandle } from "../api/createGlyphScene";
 import type { GlyphMeshTransform } from "../api/types";
 import type { GlyphSceneElement } from "./GlyphSceneElement";
@@ -20,27 +20,6 @@ const ELEMENT_BASE: typeof HTMLElement =
 
 const OBSERVED_ATTRS = ["src", "geometry", "size", "color", "position", "scale", "rotation", "normalize", "cast-shadow", "receive-shadow"] as const;
 
-/** Center and scale polygons to fit a 2-unit bounding box at origin. */
-function fitToUnitBbox(polygons: Polygon[]): Polygon[] {
-  const bbox = computeSceneBbox(polygons);
-  const cx = (bbox.min[0] + bbox.max[0]) / 2;
-  const cy = (bbox.min[1] + bbox.max[1]) / 2;
-  const cz = (bbox.min[2] + bbox.max[2]) / 2;
-  const size = Math.max(
-    bbox.max[0] - bbox.min[0],
-    bbox.max[1] - bbox.min[1],
-    bbox.max[2] - bbox.min[2],
-  ) || 1;
-  const k = 2 / size;
-  return polygons.map((p) => ({
-    ...p,
-    vertices: p.vertices.map((v): Vec3 => [
-      (v[0] - cx) * k,
-      (v[1] - cy) * k,
-      (v[2] - cz) * k,
-    ]),
-  }));
-}
 
 function parseVec3(value: string | null): Vec3 | undefined {
   if (!value) return undefined;
@@ -158,7 +137,7 @@ export class GlyphMeshElement extends ELEMENT_BASE {
       }
 
       const shouldNormalize = this.hasAttribute("normalize");
-      const polygons = shouldNormalize ? fitToUnitBbox(parsed.polygons) : parsed.polygons;
+      const polygons = shouldNormalize ? fitPolygonsToUnitBbox(parsed.polygons) : parsed.polygons;
       this._handle = scene.add(polygons, this._readTransform());
       this.dispatchEvent(new CustomEvent("glyphcss:loaded", { detail: { polygons }, bubbles: true }));
       return;

--- a/packages/react/src/glyphcss/scene/GlyphMesh.tsx
+++ b/packages/react/src/glyphcss/scene/GlyphMesh.tsx
@@ -8,7 +8,7 @@
  */
 import { memo, useEffect, useMemo, useRef } from "react";
 import type { CSSProperties, ReactNode } from "react";
-import { resolveGeometry, fitPolygonsToUnitBbox } from "@glyphcss/core";
+import { resolveGeometry, recenterPolygons } from "@glyphcss/core";
 import type { Vec3, Polygon, GlyphGeometryName } from "@glyphcss/core";
 import type { GlyphMeshTransform, GlyphPointerEvent, GlyphMouseEvent, GlyphWheelEvent } from "glyphcss";
 import { useGlyphSceneContext } from "./context";
@@ -33,10 +33,10 @@ export interface GlyphMeshProps {
   scale?: number | Vec3;
   rotation?: Vec3;
   /**
-   * Center + uniformly scale the mesh to a 2-unit bbox at the origin, so it
-   * pivots around its own center at a predictable size. Default false.
+   * Recenter the mesh's bounding-box center to the origin so it pivots around
+   * its own center (center only, no scaling — matches voxcss). Default false.
    */
-  normalize?: boolean;
+  autoCenter?: boolean;
   /**
    * This mesh casts shadows onto `receiveShadow` surfaces.
    * Default false — opt-in, matching PolyMesh behaviour.
@@ -72,7 +72,7 @@ function GlyphMeshInner({
   position,
   scale,
   rotation,
-  normalize = false,
+  autoCenter = false,
   castShadow = false,
   receiveShadow = false,
   className,
@@ -91,8 +91,8 @@ function GlyphMeshInner({
         : geometry !== undefined
           ? resolveGeometry(geometry, { size, color })
           : [];
-    return normalize ? fitPolygonsToUnitBbox(base) : base;
-  }, [polygonsProp, geometry, size, color, normalize]);
+    return autoCenter ? recenterPolygons(base) : base;
+  }, [polygonsProp, geometry, size, color, autoCenter]);
 
   const transform = useMemo<GlyphMeshTransform>(() => ({
     id,

--- a/packages/react/src/glyphcss/scene/GlyphMesh.tsx
+++ b/packages/react/src/glyphcss/scene/GlyphMesh.tsx
@@ -6,9 +6,9 @@
  * no atlas, no polygon leaves. Children are static React children mounted
  * inside the host's wrapper div (not rendered per-polygon).
  */
-import { memo, useEffect, useMemo, useRef } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
-import { resolveGeometry, recenterPolygons } from "@glyphcss/core";
+import { resolveGeometry, recenterPolygons, loadMesh } from "@glyphcss/core";
 import type { Vec3, Polygon, GlyphGeometryName } from "@glyphcss/core";
 import type { GlyphMeshTransform, GlyphPointerEvent, GlyphMouseEvent, GlyphWheelEvent } from "glyphcss";
 import { useGlyphSceneContext } from "./context";
@@ -18,6 +18,8 @@ import type { GlyphMeshHandle } from "./context";
 export interface GlyphMeshProps {
   id?: string;
   polygons?: Polygon[];
+  /** URL of an OBJ / GLB / glTF / VOX / STL mesh, fetched + parsed via `loadMesh`. */
+  src?: string;
   /**
    * Built-in geometry name. Resolved via `resolveGeometry` when neither
    * `polygons` nor `src` is provided.
@@ -66,6 +68,7 @@ export interface GlyphMeshProps {
 function GlyphMeshInner({
   id,
   polygons: polygonsProp,
+  src,
   geometry,
   size = 1,
   color,
@@ -83,16 +86,32 @@ function GlyphMeshInner({
   const meshRef = useRef<GlyphMeshHandle | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
 
-  // Precedence: explicit polygons > geometry shortcut
+  // Fetch + parse `src` (race-safe: late responses for a stale src are dropped).
+  const [loadedPolygons, setLoadedPolygons] = useState<Polygon[] | null>(null);
+  useEffect(() => {
+    if (!src) {
+      setLoadedPolygons(null);
+      return;
+    }
+    let cancelled = false;
+    loadMesh(src)
+      .then((result) => { if (!cancelled) setLoadedPolygons(result.polygons); })
+      .catch(() => { if (!cancelled) setLoadedPolygons([]); });
+    return () => { cancelled = true; };
+  }, [src]);
+
+  // Precedence: explicit polygons > src > geometry shortcut
   const polygons = useMemo(() => {
     const base =
       polygonsProp !== undefined
         ? polygonsProp
-        : geometry !== undefined
-          ? resolveGeometry(geometry, { size, color })
-          : [];
+        : src !== undefined
+          ? (loadedPolygons ?? [])
+          : geometry !== undefined
+            ? resolveGeometry(geometry, { size, color })
+            : [];
     return autoCenter ? recenterPolygons(base) : base;
-  }, [polygonsProp, geometry, size, color, autoCenter]);
+  }, [polygonsProp, src, loadedPolygons, geometry, size, color, autoCenter]);
 
   const transform = useMemo<GlyphMeshTransform>(() => ({
     id,

--- a/packages/react/src/glyphcss/scene/GlyphMesh.tsx
+++ b/packages/react/src/glyphcss/scene/GlyphMesh.tsx
@@ -8,7 +8,7 @@
  */
 import { memo, useEffect, useMemo, useRef } from "react";
 import type { CSSProperties, ReactNode } from "react";
-import { resolveGeometry } from "@glyphcss/core";
+import { resolveGeometry, fitPolygonsToUnitBbox } from "@glyphcss/core";
 import type { Vec3, Polygon, GlyphGeometryName } from "@glyphcss/core";
 import type { GlyphMeshTransform, GlyphPointerEvent, GlyphMouseEvent, GlyphWheelEvent } from "glyphcss";
 import { useGlyphSceneContext } from "./context";
@@ -32,6 +32,11 @@ export interface GlyphMeshProps {
   position?: Vec3;
   scale?: number | Vec3;
   rotation?: Vec3;
+  /**
+   * Center + uniformly scale the mesh to a 2-unit bbox at the origin, so it
+   * pivots around its own center at a predictable size. Default false.
+   */
+  normalize?: boolean;
   /**
    * This mesh casts shadows onto `receiveShadow` surfaces.
    * Default false — opt-in, matching PolyMesh behaviour.
@@ -67,6 +72,7 @@ function GlyphMeshInner({
   position,
   scale,
   rotation,
+  normalize = false,
   castShadow = false,
   receiveShadow = false,
   className,
@@ -79,10 +85,14 @@ function GlyphMeshInner({
 
   // Precedence: explicit polygons > geometry shortcut
   const polygons = useMemo(() => {
-    if (polygonsProp !== undefined) return polygonsProp;
-    if (geometry !== undefined) return resolveGeometry(geometry, { size, color });
-    return [];
-  }, [polygonsProp, geometry, size, color]);
+    const base =
+      polygonsProp !== undefined
+        ? polygonsProp
+        : geometry !== undefined
+          ? resolveGeometry(geometry, { size, color })
+          : [];
+    return normalize ? fitPolygonsToUnitBbox(base) : base;
+  }, [polygonsProp, geometry, size, color, normalize]);
 
   const transform = useMemo<GlyphMeshTransform>(() => ({
     id,

--- a/packages/vue/src/glyphcss/scene/GlyphMesh.ts
+++ b/packages/vue/src/glyphcss/scene/GlyphMesh.ts
@@ -5,7 +5,7 @@
  */
 import { defineComponent, h, inject, onBeforeUnmount, watch, shallowRef, computed, watchEffect } from "vue";
 import type { PropType } from "vue";
-import { resolveGeometry } from "@glyphcss/core";
+import { resolveGeometry, fitPolygonsToUnitBbox } from "@glyphcss/core";
 import type { Vec3, Polygon, GlyphGeometryName } from "@glyphcss/core";
 import type { GlyphMeshHandle, GlyphMeshTransform, GlyphPointerEvent, GlyphMouseEvent, GlyphWheelEvent } from "glyphcss";
 import { GlyphSceneContextKey } from "./context";
@@ -27,6 +27,11 @@ export interface GlyphMeshProps {
   position?: Vec3;
   scale?: number | Vec3;
   rotation?: Vec3;
+  /**
+   * Center + uniformly scale the mesh to a 2-unit bbox at the origin, so it
+   * pivots around its own center at a predictable size. Default false.
+   */
+  normalize?: boolean;
   /**
    * This mesh casts shadows onto `receiveShadow` surfaces.
    * Default false — opt-in, matching PolyMesh behaviour.
@@ -62,6 +67,7 @@ export const GlyphMesh = defineComponent({
     position: { type: Array as unknown as PropType<Vec3>, default: undefined },
     scale: { type: [Number, Array] as unknown as PropType<number | Vec3>, default: undefined },
     rotation: { type: Array as unknown as PropType<Vec3>, default: undefined },
+    normalize: { type: Boolean, default: false },
     castShadow: { type: Boolean, default: false },
     receiveShadow: { type: Boolean, default: false },
     class: { type: String, default: undefined },
@@ -85,11 +91,13 @@ export const GlyphMesh = defineComponent({
 
     // Precedence: explicit polygons > geometry shortcut
     const resolvedPolygons = computed<Polygon[]>(() => {
-      if (props.polygons !== undefined) return props.polygons;
-      if (props.geometry !== undefined) {
-        return resolveGeometry(props.geometry, { size: props.size, color: props.color });
-      }
-      return [];
+      const base =
+        props.polygons !== undefined
+          ? props.polygons
+          : props.geometry !== undefined
+            ? resolveGeometry(props.geometry, { size: props.size, color: props.color })
+            : [];
+      return props.normalize ? fitPolygonsToUnitBbox(base) : base;
     });
 
     function buildTransform(): GlyphMeshTransform {

--- a/packages/vue/src/glyphcss/scene/GlyphMesh.ts
+++ b/packages/vue/src/glyphcss/scene/GlyphMesh.ts
@@ -5,7 +5,7 @@
  */
 import { defineComponent, h, inject, onBeforeUnmount, watch, shallowRef, computed, watchEffect } from "vue";
 import type { PropType } from "vue";
-import { resolveGeometry, fitPolygonsToUnitBbox } from "@glyphcss/core";
+import { resolveGeometry, recenterPolygons } from "@glyphcss/core";
 import type { Vec3, Polygon, GlyphGeometryName } from "@glyphcss/core";
 import type { GlyphMeshHandle, GlyphMeshTransform, GlyphPointerEvent, GlyphMouseEvent, GlyphWheelEvent } from "glyphcss";
 import { GlyphSceneContextKey } from "./context";
@@ -28,10 +28,10 @@ export interface GlyphMeshProps {
   scale?: number | Vec3;
   rotation?: Vec3;
   /**
-   * Center + uniformly scale the mesh to a 2-unit bbox at the origin, so it
-   * pivots around its own center at a predictable size. Default false.
+   * Recenter the mesh's bounding-box center to the origin so it pivots around
+   * its own center (center only, no scaling — matches voxcss). Default false.
    */
-  normalize?: boolean;
+  autoCenter?: boolean;
   /**
    * This mesh casts shadows onto `receiveShadow` surfaces.
    * Default false — opt-in, matching PolyMesh behaviour.
@@ -67,7 +67,7 @@ export const GlyphMesh = defineComponent({
     position: { type: Array as unknown as PropType<Vec3>, default: undefined },
     scale: { type: [Number, Array] as unknown as PropType<number | Vec3>, default: undefined },
     rotation: { type: Array as unknown as PropType<Vec3>, default: undefined },
-    normalize: { type: Boolean, default: false },
+    autoCenter: { type: Boolean, default: false },
     castShadow: { type: Boolean, default: false },
     receiveShadow: { type: Boolean, default: false },
     class: { type: String, default: undefined },
@@ -97,7 +97,7 @@ export const GlyphMesh = defineComponent({
           : props.geometry !== undefined
             ? resolveGeometry(props.geometry, { size: props.size, color: props.color })
             : [];
-      return props.normalize ? fitPolygonsToUnitBbox(base) : base;
+      return props.autoCenter ? recenterPolygons(base) : base;
     });
 
     function buildTransform(): GlyphMeshTransform {

--- a/packages/vue/src/glyphcss/scene/GlyphMesh.ts
+++ b/packages/vue/src/glyphcss/scene/GlyphMesh.ts
@@ -5,7 +5,7 @@
  */
 import { defineComponent, h, inject, onBeforeUnmount, watch, shallowRef, computed, watchEffect } from "vue";
 import type { PropType } from "vue";
-import { resolveGeometry, recenterPolygons } from "@glyphcss/core";
+import { resolveGeometry, recenterPolygons, loadMesh } from "@glyphcss/core";
 import type { Vec3, Polygon, GlyphGeometryName } from "@glyphcss/core";
 import type { GlyphMeshHandle, GlyphMeshTransform, GlyphPointerEvent, GlyphMouseEvent, GlyphWheelEvent } from "glyphcss";
 import { GlyphSceneContextKey } from "./context";
@@ -13,6 +13,8 @@ import { GlyphSceneContextKey } from "./context";
 export interface GlyphMeshProps {
   id?: string;
   polygons?: Polygon[];
+  /** URL of an OBJ / GLB / glTF / VOX / STL mesh, fetched + parsed via `loadMesh`. */
+  src?: string;
   /**
    * Built-in geometry name. Resolved via `resolveGeometry` when neither
    * `polygons` nor `src` is provided.
@@ -61,6 +63,7 @@ export const GlyphMesh = defineComponent({
   props: {
     id: { type: String, default: undefined },
     polygons: { type: Array as PropType<Polygon[]>, default: undefined },
+    src: { type: String, default: undefined },
     geometry: { type: String as PropType<GlyphGeometryName>, default: undefined },
     size: { type: Number, default: 1 },
     color: { type: String, default: undefined },
@@ -89,14 +92,31 @@ export const GlyphMesh = defineComponent({
     const { sceneRef } = ctx;
     const meshRef = shallowRef<GlyphMeshHandle | null>(null);
 
-    // Precedence: explicit polygons > geometry shortcut
+    // Fetch + parse `src` (race-safe: late responses for a stale src are dropped).
+    const loadedPolygons = shallowRef<Polygon[] | null>(null);
+    watch(
+      () => props.src,
+      (src, _prev, onCleanup) => {
+        if (!src) { loadedPolygons.value = null; return; }
+        let cancelled = false;
+        onCleanup(() => { cancelled = true; });
+        loadMesh(src)
+          .then((result) => { if (!cancelled) loadedPolygons.value = result.polygons; })
+          .catch(() => { if (!cancelled) loadedPolygons.value = []; });
+      },
+      { immediate: true },
+    );
+
+    // Precedence: explicit polygons > src > geometry shortcut
     const resolvedPolygons = computed<Polygon[]>(() => {
       const base =
         props.polygons !== undefined
           ? props.polygons
-          : props.geometry !== undefined
-            ? resolveGeometry(props.geometry, { size: props.size, color: props.color })
-            : [];
+          : props.src !== undefined
+            ? (loadedPolygons.value ?? [])
+            : props.geometry !== undefined
+              ? resolveGeometry(props.geometry, { size: props.size, color: props.color })
+              : [];
       return props.autoCenter ? recenterPolygons(base) : base;
     });
 

--- a/website/src/components/GalleryWorkbench/CodePanel.tsx
+++ b/website/src/components/GalleryWorkbench/CodePanel.tsx
@@ -67,6 +67,10 @@ function generateSnippets({ meshUrl, options, selectedPreset }: CodePanelProps):
   const palette = options.glyphPalette ?? "default";
   const useColors = options.useColors !== false;
   const autoCenter = options.autoCenter !== false;
+  // The gallery centers + unit-scales every mesh (its "autoCenter"). In the
+  // packages that's the `normalize` flag ON THE MESH, not a scene option — so
+  // the copied model pivots around its own center instead of world origin.
+  const normAttr = autoCenter ? " normalize" : "";
   const lineHeight = options.lineHeight ?? 1;
   const featureEdges = options.featureEdges ?? 0;
   const rotX = options.rotX ?? 0;
@@ -93,8 +97,8 @@ function generateSnippets({ meshUrl, options, selectedPreset }: CodePanelProps):
   const featureEdgesProp = mode === "wireframe" ? ` featureEdges={${fmt(featureEdges)}}` : "";
   const targetReact = hasTarget ? `\n      target={${vec3(target)}}` : "";
   const meshTagReact = isPrimitive
-    ? `<GlyphMesh geometry="${geometryName}"${needsUpright ? ` rotation={${vec3(uprightRotation)}}` : ""} />`
-    : `<GlyphMesh src="${url}" />`;
+    ? `<GlyphMesh geometry="${geometryName}"${needsUpright ? ` rotation={${vec3(uprightRotation)}}` : ""}${normAttr} />`
+    : `<GlyphMesh src="${url}"${normAttr} />`;
 
   const react = `import {
   ${cameraComponentName},
@@ -119,7 +123,6 @@ export function App() {
         style={{ width: "100%", height: "100%", fontSize: 13 }}
         glyphPalette="${palette}"
         useColors={${useColors}}
-        autoCenter={${autoCenter}}
         lineHeight={${fmt(lineHeight)}}${featureEdgesProp}${targetReact}
         directionalLight={directionalLight}
         ambientLight={ambientLight}
@@ -139,8 +142,8 @@ export function App() {
   const featureEdgesVue = mode === "wireframe" ? `\n    :feature-edges="${fmt(featureEdges)}"` : "";
   const targetVue = hasTarget ? `\n    :target="${vec3(target)}"` : "";
   const meshTagVue = isPrimitive
-    ? `<GlyphMesh geometry="${geometryName}"${needsUpright ? ` :rotation="${vec3(uprightRotation)}"` : ""} />`
-    : `<GlyphMesh src="${url}" />`;
+    ? `<GlyphMesh geometry="${geometryName}"${needsUpright ? ` :rotation="${vec3(uprightRotation)}"` : ""}${normAttr} />`
+    : `<GlyphMesh src="${url}"${normAttr} />`;
 
   const vue = `<template>
   ${cameraOpenTagVue}
@@ -150,7 +153,6 @@ export function App() {
       :style="{ width: '100%', height: '100%', fontSize: '13px' }"
       glyphPalette="${palette}"
       :use-colors="${useColors}"
-      :auto-center="${autoCenter}"
       :line-height="${fmt(lineHeight)}"${featureEdgesVue}${targetVue}
       :directional-light="directionalLight"
       :ambient-light="ambientLight"
@@ -185,17 +187,19 @@ const ambientLight = { intensity: ${fmt(ambientIntensity)}, color: "${ambientCol
   const featureEdgesV = mode === "wireframe" ? `\n  featureEdges: ${fmt(featureEdges)},` : "";
   const targetV = hasTarget ? `\ncamera.target = ${vec3(target)};` : "";
   const meshImportV = isPrimitive ? "" : "\n  loadMesh,";
+  const fitImportV = autoCenter ? "\n  fitPolygonsToUnitBbox," : "";
   const polygonsImportV = isPrimitive ? '\nimport { resolveGeometry } from "@glyphcss/core";' : "";
+  const addArgV = autoCenter ? "fitPolygonsToUnitBbox(polygons)" : "polygons";
   const meshLoadV = isPrimitive
     ? `const polygons = resolveGeometry("${geometryName}", { size: 1 });
-scene.add(polygons${needsUpright ? `, { rotation: ${vec3(uprightRotation)} }` : ""});`
+scene.add(${addArgV}${needsUpright ? `, { rotation: ${vec3(uprightRotation)} }` : ""});`
     : `const { polygons } = await loadMesh("${url}");
-scene.add(polygons);`;
+scene.add(${addArgV});`;
 
   const vanilla = `import {
   ${cameraImport},
   createGlyphScene,
-  createGlyphOrbitControls,${meshImportV}
+  createGlyphOrbitControls,${meshImportV}${fitImportV}
 } from "glyphcss";${polygonsImportV}
 
 const host = document.querySelector<HTMLElement>("#scene")!;
@@ -210,7 +214,6 @@ const scene = createGlyphScene(host, {
   autoSize: true,
   glyphPalette: "${palette}",
   useColors: ${useColors},
-  autoCenter: ${autoCenter},
   lineHeight: ${fmt(lineHeight)},${featureEdgesV}
   directionalLight: {
     direction: ${vec3(lightDir)},
@@ -232,8 +235,8 @@ createGlyphOrbitControls(scene, { drag: true, wheel: true });`;
   const cameraCloseHtml = `</${cameraHtmlTag}>`;
   const featureEdgesHtml = mode === "wireframe" ? ` feature-edges="${fmt(featureEdges)}"` : "";
   const meshTagHtml = isPrimitive
-    ? `<glyph-mesh geometry="${geometryName}"${needsUpright ? ` rotation="${fmt(uprightRotation[0])},${fmt(uprightRotation[1])},${fmt(uprightRotation[2])}"` : ""}></glyph-mesh>`
-    : `<glyph-mesh src="${url}"></glyph-mesh>`;
+    ? `<glyph-mesh geometry="${geometryName}"${needsUpright ? ` rotation="${fmt(uprightRotation[0])},${fmt(uprightRotation[1])},${fmt(uprightRotation[2])}"` : ""}${normAttr}></glyph-mesh>`
+    : `<glyph-mesh src="${url}"${normAttr}></glyph-mesh>`;
 
   const html = `<!DOCTYPE html>
 <html>
@@ -251,7 +254,6 @@ createGlyphOrbitControls(scene, { drag: true, wheel: true });`;
         auto-size
         glyph-palette="${palette}"
         use-colors="${useColors}"
-        auto-center="${autoCenter}"
         line-height="${fmt(lineHeight)}"${featureEdgesHtml}
         light-direction="${fmt(lightDir[0])},${fmt(lightDir[1])},${fmt(lightDir[2])}"
         light-intensity="${fmt(lightIntensity)}"

--- a/website/src/components/GalleryWorkbench/CodePanel.tsx
+++ b/website/src/components/GalleryWorkbench/CodePanel.tsx
@@ -67,10 +67,12 @@ function generateSnippets({ meshUrl, options, selectedPreset }: CodePanelProps):
   const palette = options.glyphPalette ?? "default";
   const useColors = options.useColors !== false;
   const autoCenter = options.autoCenter !== false;
-  // The gallery centers + unit-scales every mesh (its "autoCenter"). In the
-  // packages that's the `normalize` flag ON THE MESH, not a scene option — so
-  // the copied model pivots around its own center instead of world origin.
-  const normAttr = autoCenter ? " normalize" : "";
+  // The gallery recenters every mesh to its own center (voxcss `autoCenter`).
+  // In the packages that's `autoCenter` ON THE MESH, not a scene option — so the
+  // copied model pivots around its own center instead of world origin. (camelCase
+  // for React/JSX; kebab-case for the custom element + Vue template.)
+  const centerJsx = autoCenter ? " autoCenter" : "";
+  const centerKebab = autoCenter ? " auto-center" : "";
   const lineHeight = options.lineHeight ?? 1;
   const featureEdges = options.featureEdges ?? 0;
   const rotX = options.rotX ?? 0;
@@ -97,8 +99,8 @@ function generateSnippets({ meshUrl, options, selectedPreset }: CodePanelProps):
   const featureEdgesProp = mode === "wireframe" ? ` featureEdges={${fmt(featureEdges)}}` : "";
   const targetReact = hasTarget ? `\n      target={${vec3(target)}}` : "";
   const meshTagReact = isPrimitive
-    ? `<GlyphMesh geometry="${geometryName}"${needsUpright ? ` rotation={${vec3(uprightRotation)}}` : ""}${normAttr} />`
-    : `<GlyphMesh src="${url}"${normAttr} />`;
+    ? `<GlyphMesh geometry="${geometryName}"${needsUpright ? ` rotation={${vec3(uprightRotation)}}` : ""}${centerJsx} />`
+    : `<GlyphMesh src="${url}"${centerJsx} />`;
 
   const react = `import {
   ${cameraComponentName},
@@ -142,8 +144,8 @@ export function App() {
   const featureEdgesVue = mode === "wireframe" ? `\n    :feature-edges="${fmt(featureEdges)}"` : "";
   const targetVue = hasTarget ? `\n    :target="${vec3(target)}"` : "";
   const meshTagVue = isPrimitive
-    ? `<GlyphMesh geometry="${geometryName}"${needsUpright ? ` :rotation="${vec3(uprightRotation)}"` : ""}${normAttr} />`
-    : `<GlyphMesh src="${url}"${normAttr} />`;
+    ? `<GlyphMesh geometry="${geometryName}"${needsUpright ? ` :rotation="${vec3(uprightRotation)}"` : ""}${centerKebab} />`
+    : `<GlyphMesh src="${url}"${centerKebab} />`;
 
   const vue = `<template>
   ${cameraOpenTagVue}
@@ -187,9 +189,9 @@ const ambientLight = { intensity: ${fmt(ambientIntensity)}, color: "${ambientCol
   const featureEdgesV = mode === "wireframe" ? `\n  featureEdges: ${fmt(featureEdges)},` : "";
   const targetV = hasTarget ? `\ncamera.target = ${vec3(target)};` : "";
   const meshImportV = isPrimitive ? "" : "\n  loadMesh,";
-  const fitImportV = autoCenter ? "\n  fitPolygonsToUnitBbox," : "";
+  const fitImportV = autoCenter ? "\n  recenterPolygons," : "";
   const polygonsImportV = isPrimitive ? '\nimport { resolveGeometry } from "@glyphcss/core";' : "";
-  const addArgV = autoCenter ? "fitPolygonsToUnitBbox(polygons)" : "polygons";
+  const addArgV = autoCenter ? "recenterPolygons(polygons)" : "polygons";
   const meshLoadV = isPrimitive
     ? `const polygons = resolveGeometry("${geometryName}", { size: 1 });
 scene.add(${addArgV}${needsUpright ? `, { rotation: ${vec3(uprightRotation)} }` : ""});`
@@ -235,8 +237,8 @@ createGlyphOrbitControls(scene, { drag: true, wheel: true });`;
   const cameraCloseHtml = `</${cameraHtmlTag}>`;
   const featureEdgesHtml = mode === "wireframe" ? ` feature-edges="${fmt(featureEdges)}"` : "";
   const meshTagHtml = isPrimitive
-    ? `<glyph-mesh geometry="${geometryName}"${needsUpright ? ` rotation="${fmt(uprightRotation[0])},${fmt(uprightRotation[1])},${fmt(uprightRotation[2])}"` : ""}${normAttr}></glyph-mesh>`
-    : `<glyph-mesh src="${url}"${normAttr}></glyph-mesh>`;
+    ? `<glyph-mesh geometry="${geometryName}"${needsUpright ? ` rotation="${fmt(uprightRotation[0])},${fmt(uprightRotation[1])},${fmt(uprightRotation[2])}"` : ""}${centerKebab}></glyph-mesh>`
+    : `<glyph-mesh src="${url}"${centerKebab}></glyph-mesh>`;
 
   const html = `<!DOCTYPE html>
 <html>

--- a/website/src/content/docs/api/html.mdx
+++ b/website/src/content/docs/api/html.mdx
@@ -94,7 +94,7 @@ Polygon registration. Picks one source in descending precedence: `geometry`
 | `position` | `x,y,z` translation |
 | `scale` | `s` or `sx,sy,sz` |
 | `rotation` | `rx,ry,rz` XYZ Euler degrees |
-| `normalize` | flag — auto-fit imported mesh to a unit bbox |
+| `auto-center` | flag — recenter the mesh's bbox center to the origin so it pivots around its own center (center only) |
 | `cast-shadow` | flag — this mesh casts shadows onto `receive-shadow` surfaces |
 | `receive-shadow` | flag — this mesh displays shadows from `cast-shadow` meshes. Present on both = self-shadow |
 

--- a/website/src/glyph-runtime.ts
+++ b/website/src/glyph-runtime.ts
@@ -167,8 +167,9 @@ function fanTriangulate(polygons: Polygon[]): TextureTriangle[] {
   return triangles;
 }
 
-/** Re-center + uniform-scale polygons of any vertex count into a 2-unit bbox. */
-function fitPolygonsToUnitBbox(polygons: Polygon[]): Polygon[] {
+/** Re-center polygons so their bbox center sits at the origin (center only, no
+ * scaling — matches voxcss `autoCenter`). The camera auto-fit handles size. */
+function recenterPolygons(polygons: Polygon[]): Polygon[] {
   if (polygons.length === 0) return polygons;
   let minX = Infinity, minY = Infinity, minZ = Infinity;
   let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
@@ -178,15 +179,9 @@ function fitPolygonsToUnitBbox(polygons: Polygon[]): Polygon[] {
     if (v[2] < minZ) minZ = v[2]; if (v[2] > maxZ) maxZ = v[2];
   }
   const cx = (minX + maxX) / 2, cy = (minY + maxY) / 2, cz = (minZ + maxZ) / 2;
-  const size = Math.max(maxX - minX, maxY - minY, maxZ - minZ) || 1;
-  const k = 2 / size;
   return polygons.map((p) => ({
     ...p,
-    vertices: p.vertices.map((v) => [
-      (v[0] - cx) * k,
-      (v[1] - cy) * k,
-      (v[2] - cz) * k,
-    ]) as Polygon["vertices"],
+    vertices: p.vertices.map((v) => [v[0] - cx, v[1] - cy, v[2] - cz]) as Polygon["vertices"],
   }));
 }
 
@@ -258,8 +253,22 @@ function polygonsToWireframeEdges(polygons: Polygon[], featureAngleDeg = 0): Wir
   return out;
 }
 
-/** Recenter + scale triangles to fit a unit bbox. */
-function fitTrianglesToUnitBbox(triangles: TextureTriangle[]): TextureTriangle[] {
+/** Largest bounding-box dimension of a polygon set (0 if empty). Used to scale
+ * world-unit params (shadow lift) now that meshes keep their authored scale. */
+function bboxMaxDim(polygons: Polygon[]): number {
+  if (!polygons || polygons.length === 0) return 0;
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  for (const p of polygons) for (const v of p.vertices) {
+    if (v[0] < minX) minX = v[0]; if (v[0] > maxX) maxX = v[0];
+    if (v[1] < minY) minY = v[1]; if (v[1] > maxY) maxY = v[1];
+    if (v[2] < minZ) minZ = v[2]; if (v[2] > maxZ) maxZ = v[2];
+  }
+  return Math.max(maxX - minX, maxY - minY, maxZ - minZ);
+}
+
+/** Recenter triangles so their bbox center sits at the origin (center only). */
+function recenterTriangles(triangles: TextureTriangle[]): TextureTriangle[] {
   if (triangles.length === 0) return triangles;
   let minX = Infinity, minY = Infinity, minZ = Infinity;
   let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
@@ -269,15 +278,9 @@ function fitTrianglesToUnitBbox(triangles: TextureTriangle[]): TextureTriangle[]
     if (v[2] < minZ) minZ = v[2]; if (v[2] > maxZ) maxZ = v[2];
   }
   const cx = (minX + maxX) / 2, cy = (minY + maxY) / 2, cz = (minZ + maxZ) / 2;
-  const size = Math.max(maxX - minX, maxY - minY, maxZ - minZ) || 1;
-  const k = 2 / size;
   return triangles.map((t) => ({
     ...t,
-    vertices: t.vertices.map((v) => [
-      (v[0] - cx) * k,
-      (v[1] - cy) * k,
-      (v[2] - cz) * k,
-    ]) as TextureTriangle["vertices"],
+    vertices: t.vertices.map((v) => [v[0] - cx, v[1] - cy, v[2] - cz]) as TextureTriangle["vertices"],
   }));
 }
 
@@ -299,7 +302,7 @@ async function loadMeshAsGeometry(url: string, normalize = true, mtlUrl?: string
   // The old per-face `bakeSolidTextureSamples` flat-color pass is gone; faces
   // without a decodable texture fall back to their MTL `Kd` color.
   const rawTris = fanTriangulate(result.polygons);
-  const polys = normalize ? fitTrianglesToUnitBbox(rawTris) : rawTris;
+  const polys = normalize ? recenterTriangles(rawTris) : rawTris;
   const edges = trianglesToEdges(polys, 0);
   const vertSet = new Map<string, Vec3>();
   for (const e of edges) {
@@ -313,7 +316,7 @@ async function loadMeshAsGeometry(url: string, normalize = true, mtlUrl?: string
     sample = (clipIndex: number, time: number) => {
       const rawPolys = animation.sample(clipIndex, time);
       const raw = fanTriangulate(rawPolys);
-      return normalize ? fitTrianglesToUnitBbox(raw) : raw;
+      return normalize ? recenterTriangles(raw) : raw;
     };
   } else {
     sample = () => polys;
@@ -723,7 +726,7 @@ function initGlyphDemo(demoEl: HTMLElement): void {
         color: lightingState.ambientColor,
       },
       shadow: shadowState.enabled
-        ? { color: shadowState.color, opacity: shadowState.opacity, lift: shadowState.lift }
+        ? { color: shadowState.color, opacity: shadowState.opacity, lift: shadowState.lift * Math.max(bboxMaxDim(geometry.polygons as Polygon[]) / 2, 0.001) }
         : undefined,
     };
   }
@@ -764,7 +767,7 @@ function initGlyphDemo(demoEl: HTMLElement): void {
    * Compute the floor polygon from the current geometry's bounding box.
    * +Z is world-up. The floor sits at the model's min-Z edge, sized 1.6× the
    * model's XY footprint so the shadow spills visibly beyond the model silhouette.
-   * The model is always centered at XY=0 after fitPolygonsToUnitBbox/loadMesh
+   * The model is always centered at XY=0 after recenterPolygons/loadMesh
    * auto-center, so offset=[0,0] places the floor quad at the XY origin.
    */
   function buildFloorPolygons(): Polygon[] {
@@ -1204,7 +1207,7 @@ function initGlyphDemo(demoEl: HTMLElement): void {
     // pentagons (30 outline edges). Fan-triangulating first would feed
     // triangles into trianglesToEdges and reintroduce spurious diagonals.
     // The rasterizer handles N-gons internally (fan-triangulates per render).
-    const fitted = fitPolygonsToUnitBbox(polygons);
+    const fitted = recenterPolygons(polygons);
     // Triangles for downstream code paths that still expect TextureTriangle[]:
     // sampler, selection picking, stats. They only need geometry-equivalent
     // triangles for hit testing — the wireframe path uses `fitted` directly.
@@ -1635,7 +1638,7 @@ function initGlyphDemo(demoEl: HTMLElement): void {
     Object.assign(shadowState, partial);
     scene.setOptions({
       shadow: shadowState.enabled
-        ? { color: shadowState.color, opacity: shadowState.opacity, lift: shadowState.lift }
+        ? { color: shadowState.color, opacity: shadowState.opacity, lift: shadowState.lift * Math.max(bboxMaxDim(geometry.polygons as Polygon[]) / 2, 0.001) }
         : undefined,
     });
     // When cast/receive flags change we must rebuild the mesh handle so the


### PR DESCRIPTION
Copied gallery code didn't center the model — it pivoted around world origin. Root cause: the generator emitted `auto-center` on the **scene** (no package supports that → silent no-op), and glyphcss had drifted from voxcss's API.

## True voxcss parity
voxcss has a working **`autoCenter`** (React/Vue prop, `auto-center` attribute), center-only: recenter the bbox center to the origin; the camera's fit/zoom handles size. glyphcss had **no `autoCenter`** and instead a `normalize` (center+scale) flag voxcss doesn't have. This aligns glyphcss to voxcss exactly **and** closes the React/Vue `src` gap:

- **core:** `recenterPolygons` (center-only), exported.
- **element / React / Vue `GlyphMesh`:** `auto-center` / `autoCenter` (center-only). `normalize` removed (clean break).
- **React + Vue `GlyphMesh` now load `src`** (URL → `loadMesh`, race-safe) — previously only the element did; the React/Vue components silently ignored `src`.
- **gallery runtime:** recenters only (no unit-scaling); the bounding-sphere auto-fit handles size (mirrors voxcss's `autoCenter + per-model zoom`). Shadow `lift` is scaled by model bbox size now that meshes keep their authored scale.
- **generator:** emits `autoCenter`/`auto-center`/`recenterPolygons(...)`; drops the bogus scene `auto-center`.
- **examples:** React + Vue `solid-mesh` now use `<GlyphMesh src="/apple.glb" autoCenter />` (drops the manual loadMesh/recenter boilerplate). **docs:** `<glyph-mesh>` table updated.

## Verified
- `pnpm test` (1404 tests, all packages) + `pnpm build` green.
- Gallery centers across scales (Dog.glb ≈unit, army.vox larger); no shadow acne.
- React example (`:6175/solid-mesh/`) and Vue example (`:6176/solid-mesh/`) both render the apple centered via `src` + `autoCenter` — confirmed with screenshots.
- All four generated tabs emit `autoCenter`/`auto-center`/`recenterPolygons`, no `normalize`.

> Needs a package publish for the React/Vue/vanilla snippets to pick up `autoCenter` + `src` via esm.sh. The custom-element `auto-center` works on the current published build.
