### PR TITLE
feat(controls): voxcss parity — FPV (control+element) + controls event system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ Every public export gets a `Glyph` prefix. Exceptions are generic math/geometry 
 - **Types:** `GlyphDirectionalLight`, `GlyphAmbientLight`, `GlyphAnimationMixer`, `GlyphAnimationAction`, `GlyphAnimationClip`, `GlyphAnimationTarget`.
 - **Functions:** `createGlyphAnimationMixer`, `injectGlyphBaseStyles`.
 - **Vanilla factories:** `createGlyphScene`, `createGlyphCamera` (ortho alias), `createGlyphPerspectiveCamera`, `createGlyphOrthographicCamera`, `createGlyphOrbitControls`, `createGlyphMapControls`, `createGlyphFirstPersonControls`.
-- **HTML custom elements:** `glyph-` prefix + kebab-case. Existing tags: `<glyph-scene>`, `<glyph-mesh>`, `<glyph-hotspot>`, `<glyph-perspective-camera>`, `<glyph-orthographic-camera>`, `<glyph-camera>` (ortho alias), `<glyph-orbit-controls>`, `<glyph-map-controls>`. Any new element follows the same shape.
+- **HTML custom elements:** `glyph-` prefix + kebab-case. Existing tags: `<glyph-scene>`, `<glyph-mesh>`, `<glyph-hotspot>`, `<glyph-perspective-camera>`, `<glyph-orthographic-camera>`, `<glyph-camera>` (ortho alias), `<glyph-orbit-controls>`, `<glyph-map-controls>`, `<glyph-first-person-controls>`. Any new element follows the same shape.
 - `GlyphCamera` is the ergonomic default alias — it resolves to `GlyphOrthographicCamera`. The voxel render mode and iso/diagrammatic scenes are glyphcss's differentiator; ortho is the more representative default.
 
 ## Numeric conventions

--- a/packages/glyphcss/src/api/controls/common.ts
+++ b/packages/glyphcss/src/api/controls/common.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared controls event surface — mirrors voxcss `controls/common.ts`'s event
+ * pieces (the camera snapshot + `change`/`start`/`end` listener registry). The
+ * wheel/anim/options helpers are inlined per-control in glyphcss, so only the
+ * event types + registry live here. Used by orbit / map / first-person controls.
+ */
+import type { GlyphSceneHandle } from "../createGlyphScene";
+import type { Vec3 } from "@glyphcss/core";
+
+export interface GlyphControlsCamera {
+  rotX: number;
+  rotY: number;
+  zoom: number;
+  target: Vec3;
+  distance: number;
+}
+
+export interface GlyphControlsChangeEvent {
+  type: "change";
+  camera: GlyphControlsCamera;
+}
+
+export interface GlyphControlsInteractionEvent {
+  type: "start" | "end";
+  camera: GlyphControlsCamera;
+}
+
+export type GlyphControlsEvent = GlyphControlsChangeEvent | GlyphControlsInteractionEvent;
+export type GlyphControlsListener<E extends GlyphControlsEvent = GlyphControlsEvent> = (event: E) => void;
+
+/** Methods every control handle exposes for `change`/`start`/`end` subscription. */
+export interface GlyphControlsEventTarget {
+  addEventListener<T extends GlyphControlsEvent["type"]>(
+    type: T,
+    listener: GlyphControlsListener<Extract<GlyphControlsEvent, { type: T }>>,
+  ): void;
+  removeEventListener<T extends GlyphControlsEvent["type"]>(
+    type: T,
+    listener: GlyphControlsListener<Extract<GlyphControlsEvent, { type: T }>>,
+  ): void;
+  hasEventListener<T extends GlyphControlsEvent["type"]>(
+    type: T,
+    listener: GlyphControlsListener<Extract<GlyphControlsEvent, { type: T }>>,
+  ): boolean;
+}
+
+export interface ListenerRegistry {
+  changeListeners: GlyphControlsListener<GlyphControlsChangeEvent>[];
+  startListeners: GlyphControlsListener<GlyphControlsInteractionEvent>[];
+  endListeners: GlyphControlsListener<GlyphControlsInteractionEvent>[];
+  listenerArray: (type: GlyphControlsEvent["type"]) => GlyphControlsListener[];
+  emitChange: (snapshot: () => GlyphControlsCamera) => void;
+  emitInteraction: (type: "start" | "end", snapshot: () => GlyphControlsCamera) => void;
+}
+
+export function makeListenerRegistry(): ListenerRegistry {
+  const changeListeners: GlyphControlsListener<GlyphControlsChangeEvent>[] = [];
+  const startListeners: GlyphControlsListener<GlyphControlsInteractionEvent>[] = [];
+  const endListeners: GlyphControlsListener<GlyphControlsInteractionEvent>[] = [];
+
+  function listenerArray(type: GlyphControlsEvent["type"]): GlyphControlsListener[] {
+    if (type === "change") return changeListeners as GlyphControlsListener[];
+    if (type === "start") return startListeners as GlyphControlsListener[];
+    return endListeners as GlyphControlsListener[];
+  }
+
+  function emitChange(snapshot: () => GlyphControlsCamera): void {
+    if (changeListeners.length === 0) return;
+    const event: GlyphControlsChangeEvent = { type: "change", camera: snapshot() };
+    for (const fn of changeListeners.slice()) {
+      try { fn(event); } catch (err) { console.error("[glyphcss] controls 'change' listener threw:", err); }
+    }
+  }
+
+  function emitInteraction(type: "start" | "end", snapshot: () => GlyphControlsCamera): void {
+    const list = type === "start" ? startListeners : endListeners;
+    if (list.length === 0) return;
+    const event: GlyphControlsInteractionEvent = { type, camera: snapshot() };
+    for (const fn of list.slice()) {
+      try { fn(event); } catch (err) { console.error(`[glyphcss] controls '${type}' listener threw:`, err); }
+    }
+  }
+
+  return { changeListeners, startListeners, endListeners, listenerArray, emitChange, emitInteraction };
+}
+
+export function makeCameraSnapshot(scene: GlyphSceneHandle): () => GlyphControlsCamera {
+  return (): GlyphControlsCamera => {
+    const c = scene.camera;
+    const t = c.target ?? [0, 0, 0];
+    return {
+      rotX: c.rotX ?? 0,
+      rotY: c.rotY ?? 0,
+      zoom: c.zoom ?? 1,
+      target: [t[0], t[1], t[2]],
+      distance: c.distance ?? 0,
+    };
+  };
+}
+
+/** Build the three `addEventListener`/`removeEventListener`/`hasEventListener`
+ *  handle methods over a registry. */
+export function makeEventMethods(reg: ListenerRegistry): GlyphControlsEventTarget {
+  return {
+    addEventListener(type, listener) {
+      const arr = reg.listenerArray(type);
+      if (!arr.includes(listener as GlyphControlsListener)) arr.push(listener as GlyphControlsListener);
+    },
+    removeEventListener(type, listener) {
+      const arr = reg.listenerArray(type);
+      const i = arr.indexOf(listener as GlyphControlsListener);
+      if (i >= 0) arr.splice(i, 1);
+    },
+    hasEventListener(type, listener) {
+      return reg.listenerArray(type).includes(listener as GlyphControlsListener);
+    },
+  };
+}

--- a/packages/glyphcss/src/api/createGlyphFirstPersonControls.test.ts
+++ b/packages/glyphcss/src/api/createGlyphFirstPersonControls.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createGlyphScene } from "./createGlyphScene";
 import { createGlyphFirstPersonControls } from "./createGlyphFirstPersonControls";
 import { createGlyphOrthographicCamera } from "./createGlyphCamera";
@@ -10,34 +10,36 @@ function makeScene(): GlyphSceneHandle {
   return createGlyphScene(host, { cols: 20, rows: 10 });
 }
 
-function pd(host: Element, x: number, y: number, pointerId = 1): void {
-  host.dispatchEvent(
-    new PointerEvent("pointerdown", {
-      clientX: x, clientY: y, pointerId, isPrimary: true, bubbles: true,
-    }),
-  );
+// Controllable rAF: capture the latest scheduled callback; `step(ms)` runs one
+// tick (the control re-schedules from inside tick, which we re-capture).
+function mockRaf() {
+  let cb: FrameRequestCallback | null = null;
+  let t = 0;
+  vi.stubGlobal("requestAnimationFrame", (fn: FrameRequestCallback) => { cb = fn; return 1; });
+  vi.stubGlobal("cancelAnimationFrame", () => { cb = null; });
+  return {
+    step(ms = 16): void { t += ms; const fn = cb; cb = null; fn?.(t); },
+    restore(): void { vi.unstubAllGlobals(); },
+  };
 }
 
-function pm(host: Element, x: number, y: number, pointerId = 1): void {
-  host.dispatchEvent(
-    new PointerEvent("pointermove", {
-      clientX: x, clientY: y, pointerId, isPrimary: true, bubbles: true,
-    }),
-  );
+function keydown(code: string): void {
+  window.dispatchEvent(new KeyboardEvent("keydown", { code, bubbles: true }));
+}
+function keyup(code: string): void {
+  window.dispatchEvent(new KeyboardEvent("keyup", { code, bubbles: true }));
 }
 
-function pu(host: Element, pointerId = 1): void {
-  host.dispatchEvent(
-    new PointerEvent("pointerup", { pointerId, isPrimary: true, bubbles: true }),
-  );
+function lookMove(dx: number, dy: number): void {
+  const ev = new MouseEvent("mousemove", { bubbles: true });
+  Object.defineProperty(ev, "movementX", { value: dx });
+  Object.defineProperty(ev, "movementY", { value: dy });
+  document.dispatchEvent(ev);
 }
 
-function kd(key: string): void {
-  document.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
-}
-
-function ku(key: string): void {
-  document.dispatchEvent(new KeyboardEvent("keyup", { key, bubbles: true }));
+function setLocked(host: Element): void {
+  Object.defineProperty(document, "pointerLockElement", { value: host, configurable: true });
+  document.dispatchEvent(new Event("pointerlockchange"));
 }
 
 describe("createGlyphFirstPersonControls", () => {
@@ -45,339 +47,94 @@ describe("createGlyphFirstPersonControls", () => {
 
   beforeEach(() => {
     scene = makeScene();
-    // Reset camera to a known state
     scene.camera.rotY = 0;
-    scene.camera.rotX = 0;
+    scene.camera.rotX = 90;
     scene.camera.target = [0, 0, 0];
   });
 
   afterEach(() => {
-    // Make sure all keys are released to avoid cross-test leakage
-    for (const key of ["w", "s", "a", "d", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"]) {
-      ku(key);
+    for (const c of ["KeyW", "KeyS", "KeyA", "KeyD", "Space", "ControlLeft"]) keyup(c);
+    scene.destroy();
+  });
+
+  it("returns the full handle", () => {
+    const c = createGlyphFirstPersonControls(scene);
+    for (const m of ["update", "pause", "resume", "destroy", "lock", "unlock", "isLocked", "getOrigin", "setOrigin"]) {
+      expect(typeof (c as Record<string, unknown>)[m]).toBe("function");
     }
-    scene.destroy();
+    c.destroy();
   });
 
-  it("returns a handle with destroy()", () => {
-    const controls = createGlyphFirstPersonControls(scene);
-    expect(typeof controls.destroy).toBe("function");
-    expect(typeof controls.pause).toBe("function");
-    expect(typeof controls.resume).toBe("function");
-    expect(typeof controls.update).toBe("function");
-    controls.destroy();
-  });
-
-  it("mouse-drag right decreases rotY (look right)", () => {
-    const controls = createGlyphFirstPersonControls(scene);
-    const initialRotY = scene.camera.rotY;
-
-    pd(scene.host, 100, 100);
-    pm(scene.host, 200, 100); // dx = +100
-    pu(scene.host);
-
-    // rotY = rotY - dx * lookSpeed (deg/px) → decreases when dx > 0
-    expect(scene.camera.rotY).toBeLessThan(initialRotY);
-    controls.destroy();
-  });
-
-  it("mouse-drag left increases rotY (look left)", () => {
-    const controls = createGlyphFirstPersonControls(scene);
-    const initialRotY = scene.camera.rotY;
-
-    pd(scene.host, 200, 100);
-    pm(scene.host, 100, 100); // dx = -100
-    pu(scene.host);
-
-    expect(scene.camera.rotY).toBeGreaterThan(initialRotY);
-    controls.destroy();
-  });
-
-  it("mouse-drag down increases rotX (look down)", () => {
-    const controls = createGlyphFirstPersonControls(scene);
-    const initialRotX = scene.camera.rotX;
-
-    pd(scene.host, 100, 100);
-    pm(scene.host, 100, 200); // dy = +100
-    pu(scene.host);
-
-    expect(scene.camera.rotX).toBeGreaterThan(initialRotX);
-    controls.destroy();
-  });
-
-  it("rotX is clamped to [-90, 90] degrees", () => {
-    const controls = createGlyphFirstPersonControls(scene);
-
-    pd(scene.host, 0, 0);
-    pm(scene.host, 0, 100000); // huge dy → clamps at 90
-    pu(scene.host);
-
-    expect(scene.camera.rotX).toBeLessThanOrEqual(90);
-    expect(scene.camera.rotX).toBeGreaterThanOrEqual(-90);
-    controls.destroy();
-  });
-
-  it("rotX clamp stops exactly at 90 degrees when dragging down past limit", () => {
-    const controls = createGlyphFirstPersonControls(scene);
-    scene.camera.rotX = 0;
-
-    // lookSpeed=0.15 deg/px, drag 1000 px down → 150 deg, clamped to 90
-    pd(scene.host, 0, 0);
-    pm(scene.host, 0, 1000);
-    pu(scene.host);
-
-    expect(scene.camera.rotX).toBe(90);
-    controls.destroy();
-  });
-
-  it("drag of 100 px rotates by 15 degrees with default lookSpeed=0.15", () => {
-    const controls = createGlyphFirstPersonControls(scene);
-    scene.camera.rotY = 0;
-
-    pd(scene.host, 0, 0);
-    pm(scene.host, 100, 0); // dx = +100
-    pu(scene.host);
-
-    // rotY = 0 - 100 * 0.15 = -15 degrees
-    expect(scene.camera.rotY).toBeCloseTo(-15, 5);
-    controls.destroy();
-  });
-
-  it("lookSpeed option scales mouse-drag rotation magnitude", () => {
-    const controlsFast = createGlyphFirstPersonControls(scene, { lookSpeed: 0.01 });
-    const dx = 100;
-
-    pd(scene.host, 0, 0);
-    pm(scene.host, dx, 0);
-    pu(scene.host);
-
-    const rotYFast = scene.camera.rotY;
-
-    // Reset
-    controlsFast.destroy();
-    scene.camera.rotY = 0;
-
-    const controlsSlow = createGlyphFirstPersonControls(scene, { lookSpeed: 0.001 });
-    pd(scene.host, 0, 0);
-    pm(scene.host, dx, 0);
-    pu(scene.host);
-
-    const rotYSlow = scene.camera.rotY;
-    controlsSlow.destroy();
-
-    // Fast lookSpeed → larger rotation magnitude
-    expect(Math.abs(rotYFast)).toBeGreaterThan(Math.abs(rotYSlow));
-  });
-
-  it("invert option reverses drag direction", () => {
-    const controls = createGlyphFirstPersonControls(scene, { invert: true });
-    const initialRotY = scene.camera.rotY;
-
-    pd(scene.host, 100, 100);
-    pm(scene.host, 200, 100); // dx = +100, invert → rotY increases
-    pu(scene.host);
-
-    expect(scene.camera.rotY).toBeGreaterThan(initialRotY);
-    controls.destroy();
-  });
-
-  it("'w' key moves camera target forward (negative z-ish in camera space)", async () => {
-    const controls = createGlyphFirstPersonControls(scene, { keyboard: true });
-    // rotY=0: forward = sinY=0, cosY=1 → target moves toward -cosY direction
-    const initialY = scene.camera.target[1];
-
-    kd("w");
-    // The keyTick is driven by rAF which may not fire in happy-dom;
-    // directly call the scene's rerender to flush any pending state — but
-    // key processing is rAF-driven. We simulate by re-dispatching keydown
-    // and manually invoking rerender in a microtask to at least verify
-    // the key registration. Instead, check if holding 'w' for one keyTick
-    // produces movement when we trigger the RAF manually via a real rAF call.
-    // In happy-dom, requestAnimationFrame callbacks fire in next microtask.
-    await new Promise((r) => requestAnimationFrame(r));
-    ku("w");
-
-    // At rotY=0: cosY=1, sinY=0; 'w' → target[1] -= cosY * moveSpeed → decreases
-    expect(scene.camera.target[1]).toBeLessThan(initialY);
-    controls.destroy();
-  });
-
-  it("'s' key moves camera target backward", async () => {
-    const controls = createGlyphFirstPersonControls(scene, { keyboard: true });
-    const initialY = scene.camera.target[1];
-
-    kd("s");
-    await new Promise((r) => requestAnimationFrame(r));
-    ku("s");
-
-    // 's' → target[1] += cosY * moveSpeed → increases
-    expect(scene.camera.target[1]).toBeGreaterThan(initialY);
-    controls.destroy();
-  });
-
-  it("'a' key strafes left (target.x decreases at rotY=0)", async () => {
-    const controls = createGlyphFirstPersonControls(scene, { keyboard: true });
-    const initialX = scene.camera.target[0];
-
-    kd("a");
-    await new Promise((r) => requestAnimationFrame(r));
-    ku("a");
-
-    // 'a' → target[0] -= cosY * moveSpeed → decreases at rotY=0 (cosY=1)
-    expect(scene.camera.target[0]).toBeLessThan(initialX);
-    controls.destroy();
-  });
-
-  it("'d' key strafes right (target.x increases at rotY=0)", async () => {
-    const controls = createGlyphFirstPersonControls(scene, { keyboard: true });
-    const initialX = scene.camera.target[0];
-
-    kd("d");
-    await new Promise((r) => requestAnimationFrame(r));
-    ku("d");
-
-    // 'd' → target[0] += cosY * moveSpeed → increases at rotY=0
-    expect(scene.camera.target[0]).toBeGreaterThan(initialX);
-    controls.destroy();
-  });
-
-  it("moveSpeed option scales keyboard movement magnitude", async () => {
-    const controlsFast = createGlyphFirstPersonControls(scene, { moveSpeed: 0.5 });
-    kd("w");
-    await new Promise((r) => requestAnimationFrame(r));
-    ku("w");
-    const fastDelta = Math.abs(scene.camera.target[1]);
-
-    controlsFast.destroy();
-    scene.camera.target = [0, 0, 0];
-
-    const controlsSlow = createGlyphFirstPersonControls(scene, { moveSpeed: 0.01 });
-    kd("w");
-    await new Promise((r) => requestAnimationFrame(r));
-    ku("w");
-    const slowDelta = Math.abs(scene.camera.target[1]);
-    controlsSlow.destroy();
-
-    expect(fastDelta).toBeGreaterThan(slowDelta);
-  });
-
-  it("arrow keys also move the camera", async () => {
-    const controls = createGlyphFirstPersonControls(scene, { keyboard: true });
-    const initialY = scene.camera.target[1];
-
-    kd("ArrowUp");
-    await new Promise((r) => requestAnimationFrame(r));
-    ku("ArrowUp");
-
-    expect(scene.camera.target[1]).not.toBe(initialY);
-    controls.destroy();
-  });
-
-  it("destroy() stops responding to mouse-drag events", () => {
-    const controls = createGlyphFirstPersonControls(scene);
-    controls.destroy();
-
-    const rotYBefore = scene.camera.rotY;
-    pd(scene.host, 100, 100);
-    pm(scene.host, 300, 100);
-    pu(scene.host);
-
-    expect(scene.camera.rotY).toBe(rotYBefore);
-  });
-
-  it("destroy() stops keyboard processing", async () => {
-    const controls = createGlyphFirstPersonControls(scene, { keyboard: true });
-    controls.destroy();
-
-    const initialY = scene.camera.target[1];
-    kd("w");
-    await new Promise((r) => requestAnimationFrame(r));
-    ku("w");
-
-    expect(scene.camera.target[1]).toBe(initialY);
-  });
-
-  it("pause() stops drag handling; resume() restores it", () => {
-    const controls = createGlyphFirstPersonControls(scene);
-    controls.pause();
-
-    const rotYBefore = scene.camera.rotY;
-    pd(scene.host, 100, 100);
-    pm(scene.host, 300, 100);
-    pu(scene.host);
-    expect(scene.camera.rotY).toBe(rotYBefore);
-
-    controls.resume();
-    pd(scene.host, 100, 100);
-    pm(scene.host, 300, 100);
-    pu(scene.host);
-    expect(scene.camera.rotY).not.toBe(rotYBefore);
-
-    controls.destroy();
-  });
-
-  it("drag disabled via option produces no rotation", () => {
-    const controls = createGlyphFirstPersonControls(scene, { drag: false });
-    const initialRotY = scene.camera.rotY;
-
-    pd(scene.host, 100, 100);
-    pm(scene.host, 300, 100);
-    pu(scene.host);
-
-    expect(scene.camera.rotY).toBe(initialRotY);
-    controls.destroy();
-  });
-
-  it("keyboard disabled via option produces no movement on key press", async () => {
-    const controls = createGlyphFirstPersonControls(scene, { keyboard: false });
-    const initialY = scene.camera.target[1];
-
-    kd("w");
-    await new Promise((r) => requestAnimationFrame(r));
-    ku("w");
-
-    expect(scene.camera.target[1]).toBe(initialY);
-    controls.destroy();
-  });
-
-  it("pointermove without pointerdown is a no-op", () => {
-    const controls = createGlyphFirstPersonControls(scene);
-    const initialRotY = scene.camera.rotY;
-
-    pm(scene.host, 300, 100);
-
-    expect(scene.camera.rotY).toBe(initialRotY);
-    controls.destroy();
-  });
-
-  it("sets eyeMode=true on the camera at attach time", () => {
-    expect(scene.camera.eyeMode).toBe(false);
-    const controls = createGlyphFirstPersonControls(scene);
-    expect(scene.camera.eyeMode).toBe(true);
-    controls.destroy();
-  });
-
-  it("restores eyeMode=false on the camera after destroy", () => {
-    const controls = createGlyphFirstPersonControls(scene);
-    expect(scene.camera.eyeMode).toBe(true);
-    controls.destroy();
-    expect(scene.camera.eyeMode).toBe(false);
-  });
-});
-
-describe("createGlyphFirstPersonControls — orthographic camera rejection", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
-  it("throws when the scene has an orthographic camera", () => {
+  it("requires a perspective camera", () => {
     const host = document.createElement("div");
-    document.body.appendChild(host);
-    const orthoCamera = createGlyphOrthographicCamera();
-    const scene = createGlyphScene(host, { camera: orthoCamera, cols: 20, rows: 10 });
-    expect(() => createGlyphFirstPersonControls(scene)).toThrow(
-      /GlyphFirstPersonControls requires a perspective camera/,
-    );
-    scene.destroy();
+    const ortho = createGlyphScene(host, { cols: 10, rows: 10, camera: createGlyphOrthographicCamera() });
+    expect(() => createGlyphFirstPersonControls(ortho)).toThrow(/perspective camera/);
+    ortho.destroy();
+  });
+
+  it("enables eyeMode on attach and restores it on destroy", () => {
+    const c = createGlyphFirstPersonControls(scene);
+    expect(scene.camera.eyeMode).toBe(true);
+    c.destroy();
+    expect(scene.camera.eyeMode).toBe(false);
+  });
+
+  it("seeds the eye from target + eyeHeight; setOrigin/getOrigin round-trip", () => {
+    const c = createGlyphFirstPersonControls(scene, { eyeHeight: 1.7, groundZ: 0 });
+    expect(c.getOrigin()[2]).toBeCloseTo(1.7, 5);
+    c.setOrigin([5, 6, 2]);
+    expect(c.getOrigin()).toEqual([5, 6, 2]);
+    // In eyeMode the target IS the eye.
+    expect(scene.camera.target).toEqual([5, 6, 2]);
+    c.destroy();
+  });
+
+  it("pointer-lock mouselook: dx right decreases rotY, pitch clamps", () => {
+    const c = createGlyphFirstPersonControls(scene, { lookSensitivity: 0.15 });
+    setLocked(scene.host);
+    expect(c.isLocked()).toBe(true);
+    const rotY0 = scene.camera.rotY;
+    lookMove(100, 0); // dx +100 → rotY -= 15
+    expect(scene.camera.rotY).toBeCloseTo(((rotY0 - 15) % 360 + 360) % 360, 4);
+    lookMove(0, 100000); // huge pitch down → clamped to maxPitch (175)
+    expect(scene.camera.rotX).toBeLessThanOrEqual(175);
+    expect(scene.camera.rotX).toBeGreaterThanOrEqual(5);
+    c.destroy();
+  });
+
+  it("WASD walks the eye on the XY plane (rAF-driven)", () => {
+    const raf = mockRaf();
+    const c = createGlyphFirstPersonControls(scene, { moveSpeed: 10 });
+    const start = c.getOrigin();
+    keydown("KeyW");
+    raf.step(16);
+    raf.step(16);
+    const after = c.getOrigin();
+    expect(after[0] !== start[0] || after[1] !== start[1]).toBe(true);
+    keyup("KeyW");
+    c.destroy();
+    raf.restore();
+  });
+
+  it("Space jumps then gravity returns to ground (rAF-driven)", () => {
+    const raf = mockRaf();
+    const c = createGlyphFirstPersonControls(scene, { eyeHeight: 1, gravity: 18, jumpVelocity: 7 });
+    keydown("Space");
+    raf.step(16);
+    expect(c.getOrigin()[2]).toBeGreaterThan(1); // airborne
+    for (let i = 0; i < 200; i++) raf.step(16); // let gravity land it
+    expect(c.getOrigin()[2]).toBeCloseTo(1, 2);
+    c.destroy();
+    raf.restore();
+  });
+
+  it("update() can disable look", () => {
+    const c = createGlyphFirstPersonControls(scene, { lookSensitivity: 0.15 });
+    setLocked(scene.host);
+    c.update({ lookEnabled: false });
+    const rotY0 = scene.camera.rotY;
+    lookMove(100, 0);
+    expect(scene.camera.rotY).toBe(rotY0);
+    c.destroy();
   });
 });

--- a/packages/glyphcss/src/api/createGlyphFirstPersonControls.ts
+++ b/packages/glyphcss/src/api/createGlyphFirstPersonControls.ts
@@ -1,37 +1,138 @@
-// Vendored from voxcss packages/polycss/src/api/createPolyFirstPersonControls.ts@cac9da3. glyphcss deltas: Poly→Glyph rename; rotX/rotY in degrees (camera expects degrees); simplified look model (pointer-drag instead of pointer-lock; no jump/crouch); keyTick trig converts deg→rad; no addEventListener/removeEventListener (not yet in glyphcss API surface).
+// Vendored from voxcss packages/polycss/src/api/createPolyFirstPersonControls.ts@cac9da3.
+// glyphcss deltas: Poly→Glyph rename; the camera sync uses eyeMode (target IS the
+// eye, projected along rotX/rotY) instead of polycss's CSS-perspective + derived
+// look-ahead target — so there's no cameraEl/perspective-host plumbing and no
+// lookOffset. Otherwise the input model (pointer-lock mouselook, WASD planar
+// move, Space jump, Ctrl crouch, gravity) and the option/handle surface match
+// voxcss 1:1. Like voxcss, model-relative sizing (eye height / spawn / speed) is
+// the caller's job — pass proportional options (see the gallery's FPV spawn).
 /**
  * createGlyphFirstPersonControls — first-person camera input for a GlyphScene.
  *
- * Requires the scene to have a perspective camera. On attach, sets
- * `camera.eyeMode = true` so the perspective projection switches to the
- * eye-at-origin formulation (target = eye position, near-plane cull). On
- * detach, restores `eyeMode = false`.
+ * Mouselook on pointer-lock, WASD/arrow planar move in the yaw-aligned XY
+ * plane, Space jump (parametric arc, no collision), Ctrl crouch. Each input
+ * axis is independently toggleable.
  *
- * Mouse-drag looks around (rotX/rotY). WASD or arrow keys move forward/backward/strafe.
- *
- * rotX and rotY are in DEGREES (three.js / voxcss convention).
- * lookSpeed: degrees per pixel. Default: 0.15.
- * moveSpeed: world units per frame.
+ * Requires a perspective camera; sets `camera.eyeMode = true` on attach (the
+ * camera projects from `target` along rotX/rotY) and restores it on detach.
+ * rotX/rotY are in DEGREES (three.js / voxcss convention).
  */
 
 import type { GlyphSceneHandle } from "./createGlyphScene";
 import type { Vec3 } from "@glyphcss/core";
 
 export interface GlyphFirstPersonControlsOptions {
-  drag?: boolean;
-  keyboard?: boolean;
+  /** Master switch. When `false`, all sub-controls are inert. Default: `true`. */
+  enabled?: boolean;
+  /** Pointer-lock mouselook (rotX = pitch, rotY = yaw). Default: `true`. */
+  lookEnabled?: boolean;
+  /** WASD / arrow-key planar movement on world XY. Default: `true`. */
+  moveEnabled?: boolean;
+  /** Space-bar parametric jump arc on world Z. Default: `true`. */
+  jumpEnabled?: boolean;
+  /** Ctrl crouch (lowers eye height while held). Default: `true`. */
+  crouchEnabled?: boolean;
+  /** Mouselook sensitivity in degrees per pixel. Default: `0.15`. */
+  lookSensitivity?: number;
+  /** Invert vertical mouselook. Default: `false`. */
+  invertY?: boolean;
+  /** Movement speed in world units per second. Default: `5`. */
   moveSpeed?: number;
-  /** Mouselook sensitivity in degrees per pixel. Default: 0.15. */
-  lookSpeed?: number;
-  invert?: boolean | number;
+  /** Initial vertical velocity for a jump, world units per second. Default: `7`. */
+  jumpVelocity?: number;
+  /** Gravity acceleration in world units per second squared. Default: `18`. */
+  gravity?: number;
+  /** Standing eye height above the ground plane (target.z). Default: `1.7`. */
+  eyeHeight?: number;
+  /** Eye height while crouching. Default: `1`. */
+  crouchHeight?: number;
+  /** World Z of the ground plane the player walks on. Default: `0`. */
+  groundZ?: number;
+  /** Min pitch (rotX) angle. Default: `5`. */
+  minPitch?: number;
+  /** Max pitch (rotX) angle. Default: `175`. */
+  maxPitch?: number;
+}
+
+interface ResolvedOptions {
+  enabled: boolean;
+  lookEnabled: boolean;
+  moveEnabled: boolean;
+  jumpEnabled: boolean;
+  crouchEnabled: boolean;
+  lookSensitivity: number;
+  invertY: boolean;
+  moveSpeed: number;
+  jumpVelocity: number;
+  gravity: number;
+  eyeHeight: number;
+  crouchHeight: number;
+  groundZ: number;
+  minPitch: number;
+  maxPitch: number;
+}
+
+const DEFAULTS: ResolvedOptions = {
+  enabled: true,
+  lookEnabled: true,
+  moveEnabled: true,
+  jumpEnabled: true,
+  crouchEnabled: true,
+  lookSensitivity: 0.15,
+  invertY: false,
+  moveSpeed: 5,
+  jumpVelocity: 7,
+  gravity: 18,
+  eyeHeight: 1.7,
+  crouchHeight: 1,
+  groundZ: 0,
+  minPitch: 5,
+  maxPitch: 175,
+};
+
+function resolveOptions(base: ResolvedOptions, partial: GlyphFirstPersonControlsOptions): ResolvedOptions {
+  return {
+    enabled: partial.enabled ?? base.enabled,
+    lookEnabled: partial.lookEnabled ?? base.lookEnabled,
+    moveEnabled: partial.moveEnabled ?? base.moveEnabled,
+    jumpEnabled: partial.jumpEnabled ?? base.jumpEnabled,
+    crouchEnabled: partial.crouchEnabled ?? base.crouchEnabled,
+    lookSensitivity: partial.lookSensitivity ?? base.lookSensitivity,
+    invertY: partial.invertY ?? base.invertY,
+    moveSpeed: partial.moveSpeed ?? base.moveSpeed,
+    jumpVelocity: partial.jumpVelocity ?? base.jumpVelocity,
+    gravity: partial.gravity ?? base.gravity,
+    eyeHeight: partial.eyeHeight ?? base.eyeHeight,
+    crouchHeight: partial.crouchHeight ?? base.crouchHeight,
+    groundZ: partial.groundZ ?? base.groundZ,
+    minPitch: partial.minPitch ?? base.minPitch,
+    maxPitch: partial.maxPitch ?? base.maxPitch,
+  };
 }
 
 export interface GlyphFirstPersonControlsHandle {
-  update(opts: GlyphFirstPersonControlsOptions): void;
-  pause(): void;
+  update(partial: GlyphFirstPersonControlsOptions): void;
   resume(): void;
+  pause(): void;
   destroy(): void;
+  /** Request pointer-lock now. Call from a user gesture (click). */
+  lock(): void;
+  /** Release pointer-lock. */
+  unlock(): void;
+  /** Whether pointer-lock is currently held. */
+  isLocked(): boolean;
+  /** The camera's WORLD position (the eye). Mutated via WASD / jump / crouch. */
+  getOrigin(): [number, number, number];
+  /** Teleport the camera eye to a world position (e.g. spawn at a chosen spot). */
+  setOrigin(origin: [number, number, number]): void;
 }
+
+const FORWARD_KEYS = new Set(["KeyW", "ArrowUp"]);
+const BACK_KEYS = new Set(["KeyS", "ArrowDown"]);
+const LEFT_KEYS = new Set(["KeyA", "ArrowLeft"]);
+const RIGHT_KEYS = new Set(["KeyD", "ArrowRight"]);
+const JUMP_KEYS = new Set(["Space"]);
+const CROUCH_KEYS = new Set(["ControlLeft", "ControlRight"]);
 
 export function createGlyphFirstPersonControls(
   scene: GlyphSceneHandle,
@@ -43,132 +144,237 @@ export function createGlyphFirstPersonControls(
       "Use <GlyphPerspectiveCamera> (not <GlyphOrthographicCamera> / <GlyphCamera>).",
     );
   }
-  scene.camera.eyeMode = true;
 
-  const host = scene.host;
-  let drag = options.drag ?? true;
-  let keyboard = options.keyboard ?? true;
-  let moveSpeed = options.moveSpeed ?? 0.05;
-  // lookSpeed is degrees per pixel (matches voxcss lookSensitivity default of 0.15 deg/px).
-  let lookSpeed = options.lookSpeed ?? 0.15;
-  let invertFactor = resolveInvert(options.invert);
-  let stopped = false;
-  let activePointerId: number | null = null;
-  let pointer = { x: 0, y: 0 };
-  const keys = new Set<string>();
-  let rafId: ReturnType<typeof requestAnimationFrame> | null = null;
-
+  let opts: ResolvedOptions = resolveOptions(DEFAULTS, options);
   const camera = scene.camera;
+  const host = scene.host;
+  const doc = host.ownerDocument ?? document;
+  const win = (doc.defaultView ?? globalThis) as typeof globalThis;
 
-  function onPointerDown(e: PointerEvent): void {
-    if (!drag || stopped) return;
-    if (activePointerId !== null) return;
-    e.preventDefault();
-    activePointerId = e.pointerId;
-    pointer = { x: e.clientX, y: e.clientY };
-    try { (e.target as Element).setPointerCapture(e.pointerId); } catch { /* ignore */ }
-  }
+  const keysHeld = new Set<string>();
+  let pointerLocked = false;
+  let stopped = false;
 
-  function onPointerMove(e: PointerEvent): void {
-    if (activePointerId === null || e.pointerId !== activePointerId) return;
-    if (!drag || stopped) return;
-    e.preventDefault();
-    const dx = e.clientX - pointer.x;
-    const dy = e.clientY - pointer.y;
-    pointer = { x: e.clientX, y: e.clientY };
-    // lookSpeed is deg/px; rotY/rotX stored in degrees.
-    camera.rotY = camera.rotY - dx * lookSpeed * invertFactor;
-    camera.rotX = Math.max(-90, Math.min(90, camera.rotX + dy * lookSpeed * invertFactor));
+  // Vertical state, separate from origin.z so crouch + jump stack.
+  let verticalVel = 0;
+  let jumpOffset = 0;
+
+  // In eyeMode the camera projects FROM `target`, so the eye IS `target`. We
+  // keep an authoritative `cameraOrigin` and write it straight to `target`;
+  // mouselook only changes rotX/rotY (origin fixed → in-place look), WASD moves
+  // the origin.
+  let cameraOrigin: [number, number, number] = [0, 0, opts.groundZ + opts.eyeHeight];
+
+  function syncTarget(): void {
+    camera.target = [cameraOrigin[0], cameraOrigin[1], cameraOrigin[2]] as Vec3;
     scene.rerender();
   }
 
-  function onPointerUp(e: PointerEvent): void {
-    if (activePointerId !== e.pointerId) return;
-    activePointerId = null;
-    try { (e.target as Element).releasePointerCapture(e.pointerId); } catch { /* ignore */ }
+  // On attach adopt the camera's current target (the orbit/pan visual center)
+  // as the eye position, snapped to eye height. After this FPV owns `target`.
+  function initializeOriginFromTarget(): void {
+    const t = camera.target ?? [0, 0, 0];
+    cameraOrigin = [t[0], t[1], opts.groundZ + opts.eyeHeight];
+    syncTarget();
   }
 
-  function onKeyDown(e: KeyboardEvent): void { if (keyboard && !stopped) keys.add(e.key.toLowerCase()); }
-  function onKeyUp(e: KeyboardEvent): void { keys.delete(e.key.toLowerCase()); }
+  // ── Pointer-lock ─────────────────────────────────────────────────────────
+  const onHostClick = (): void => {
+    if (!opts.enabled || !opts.lookEnabled || stopped || pointerLocked) return;
+    try { host.requestPointerLock(); } catch { /* ignore */ }
+  };
 
-  function keyTick(): void {
-    if (stopped || !keyboard || keys.size === 0) return;
-    const t = camera.target;
-    // rotY is in degrees; convert to radians for trig.
-    const rotYRad = camera.rotY * Math.PI / 180;
-    const cosY = Math.cos(rotYRad), sinY = Math.sin(rotYRad);
-    let moved = false;
-    if (keys.has("w") || keys.has("arrowup")) {
-      camera.target = [t[0] - sinY * moveSpeed, t[1] - cosY * moveSpeed, t[2]] as Vec3;
-      moved = true;
+  const onPointerLockChange = (): void => {
+    pointerLocked = doc.pointerLockElement === host;
+  };
+
+  const onMouseMove = (e: MouseEvent): void => {
+    if (!pointerLocked || !opts.enabled || !opts.lookEnabled || stopped) return;
+    const dx = e.movementX ?? 0;
+    const dy = e.movementY ?? 0;
+    if (dx === 0 && dy === 0) return;
+    const sens = opts.lookSensitivity;
+    const dyDir = opts.invertY ? -1 : 1;
+    camera.rotY = ((((camera.rotY - dx * sens) % 360) + 360) % 360);
+    let rotX = camera.rotX - dy * sens * dyDir;
+    if (rotX < opts.minPitch) rotX = opts.minPitch;
+    else if (rotX > opts.maxPitch) rotX = opts.maxPitch;
+    camera.rotX = rotX;
+    syncTarget();
+  };
+
+  // ── Keyboard ─────────────────────────────────────────────────────────────
+  const isFpvKey = (code: string): boolean =>
+    FORWARD_KEYS.has(code) || BACK_KEYS.has(code) || LEFT_KEYS.has(code) ||
+    RIGHT_KEYS.has(code) || JUMP_KEYS.has(code) || CROUCH_KEYS.has(code);
+
+  const onKeyDown = (e: KeyboardEvent): void => {
+    if (!opts.enabled || stopped) return;
+    if (!isFpvKey(e.code)) return;
+    if (!pointerLocked && !opts.moveEnabled) return;
+    if (JUMP_KEYS.has(e.code)) {
+      if (!opts.jumpEnabled) return;
+      e.preventDefault();
+      if (!keysHeld.has(e.code) && verticalVel === 0 && jumpOffset === 0) {
+        verticalVel = opts.jumpVelocity;
+      }
+      keysHeld.add(e.code);
+      return;
     }
-    if (keys.has("s") || keys.has("arrowdown")) {
-      camera.target = [t[0] + sinY * moveSpeed, t[1] + cosY * moveSpeed, t[2]] as Vec3;
-      moved = true;
+    if (CROUCH_KEYS.has(e.code) && !opts.crouchEnabled) return;
+    if (!opts.moveEnabled && !CROUCH_KEYS.has(e.code)) return;
+    e.preventDefault();
+    keysHeld.add(e.code);
+  };
+
+  const onKeyUp = (e: KeyboardEvent): void => {
+    if (!isFpvKey(e.code)) return;
+    keysHeld.delete(e.code);
+  };
+
+  const onBlur = (): void => { keysHeld.clear(); };
+
+  // ── RAF tick ──────────────────────────────────────────────────────────────
+  let rafId: number | null = null;
+  let lastTime = 0;
+  const ANIM_DT_CLAMP = 0.05;
+
+  const tick = (now: number): void => {
+    if (rafId === null || stopped) return;
+    const dt = Math.min(ANIM_DT_CLAMP, lastTime ? (now - lastTime) / 1000 : 0.0167);
+    lastTime = now;
+
+    if (opts.enabled) {
+      let dirty = false;
+
+      if (opts.moveEnabled) {
+        let mf = 0, mr = 0;
+        for (const code of keysHeld) {
+          if (FORWARD_KEYS.has(code)) mf += 1;
+          else if (BACK_KEYS.has(code)) mf -= 1;
+          else if (RIGHT_KEYS.has(code)) mr += 1;
+          else if (LEFT_KEYS.has(code)) mr -= 1;
+        }
+        if (mf !== 0 || mr !== 0) {
+          const r = (camera.rotY * Math.PI) / 180;
+          // Horizontal yaw projection (pitch-independent — WASD walks the floor).
+          const fx = -Math.cos(r), fy = -Math.sin(r);
+          const rx = -Math.sin(r), ry = Math.cos(r);
+          const len = Math.hypot(mf, mr) || 1;
+          const step = opts.moveSpeed * dt;
+          cameraOrigin[0] += ((fx * mf + rx * mr) / len) * step;
+          cameraOrigin[1] += ((fy * mf + ry * mr) / len) * step;
+          dirty = true;
+        }
+      }
+
+      const crouched = opts.crouchEnabled &&
+        (keysHeld.has("ControlLeft") || keysHeld.has("ControlRight"));
+      const baseHeight = crouched ? opts.crouchHeight : opts.eyeHeight;
+      if (opts.jumpEnabled && (verticalVel !== 0 || jumpOffset > 0)) {
+        verticalVel -= opts.gravity * dt;
+        jumpOffset += verticalVel * dt;
+        if (jumpOffset <= 0) { jumpOffset = 0; verticalVel = 0; }
+      } else if (!opts.jumpEnabled) {
+        jumpOffset = 0; verticalVel = 0;
+      }
+      const originZ = opts.groundZ + baseHeight + jumpOffset;
+      if (Math.abs(cameraOrigin[2] - originZ) > 1e-4) {
+        cameraOrigin[2] = originZ;
+        dirty = true;
+      }
+
+      if (dirty) syncTarget();
     }
-    if (keys.has("a") || keys.has("arrowleft")) {
-      camera.target = [t[0] - cosY * moveSpeed, t[1] + sinY * moveSpeed, t[2]] as Vec3;
-      moved = true;
-    }
-    if (keys.has("d") || keys.has("arrowright")) {
-      camera.target = [t[0] + cosY * moveSpeed, t[1] - sinY * moveSpeed, t[2]] as Vec3;
-      moved = true;
-    }
-    if (moved) scene.rerender();
+
+    rafId = win.requestAnimationFrame(tick);
+  };
+
+  function startLoop(): void {
+    if (rafId !== null || stopped) return;
+    lastTime = 0;
+    if (typeof win.requestAnimationFrame !== "undefined") rafId = win.requestAnimationFrame(tick);
   }
 
-  function animTick(): void {
-    if (stopped) return;
-    keyTick();
-    rafId = requestAnimationFrame(animTick);
+  function stopLoop(): void {
+    if (rafId === null) return;
+    win.cancelAnimationFrame(rafId);
+    rafId = null;
   }
 
   function attach(): void {
-    host.addEventListener("pointerdown", onPointerDown);
-    host.addEventListener("pointermove", onPointerMove);
-    host.addEventListener("pointerup", onPointerUp);
-    host.addEventListener("pointercancel", onPointerUp);
-    if (keyboard) {
-      host.ownerDocument?.addEventListener("keydown", onKeyDown);
-      host.ownerDocument?.addEventListener("keyup", onKeyUp);
-    }
+    camera.eyeMode = true;
+    host.addEventListener("click", onHostClick);
+    doc.addEventListener("pointerlockchange", onPointerLockChange);
+    doc.addEventListener("mousemove", onMouseMove);
+    win.addEventListener("keydown", onKeyDown);
+    win.addEventListener("keyup", onKeyUp);
+    win.addEventListener("blur", onBlur);
+    host.style.cursor = opts.lookEnabled ? "crosshair" : "";
     host.style.touchAction = "none";
-    host.style.userSelect = "none";
-    if (typeof requestAnimationFrame !== "undefined") rafId = requestAnimationFrame(animTick);
   }
 
   function detach(): void {
-    host.removeEventListener("pointerdown", onPointerDown);
-    host.removeEventListener("pointermove", onPointerMove);
-    host.removeEventListener("pointerup", onPointerUp);
-    host.removeEventListener("pointercancel", onPointerUp);
-    host.ownerDocument?.removeEventListener("keydown", onKeyDown);
-    host.ownerDocument?.removeEventListener("keyup", onKeyUp);
+    host.removeEventListener("click", onHostClick);
+    doc.removeEventListener("pointerlockchange", onPointerLockChange);
+    doc.removeEventListener("mousemove", onMouseMove);
+    win.removeEventListener("keydown", onKeyDown);
+    win.removeEventListener("keyup", onKeyUp);
+    win.removeEventListener("blur", onBlur);
+    host.style.cursor = "";
     host.style.touchAction = "";
-    host.style.userSelect = "";
-    if (rafId !== null) { if (typeof cancelAnimationFrame !== "undefined") cancelAnimationFrame(rafId); rafId = null; }
-    keys.clear();
-    scene.camera.eyeMode = false;
+    keysHeld.clear();
+    if (pointerLocked) { try { doc.exitPointerLock(); } catch { /* ignore */ } }
+    camera.eyeMode = false;
   }
 
+  initializeOriginFromTarget();
   attach();
+  startLoop();
+
+  function update(partial: GlyphFirstPersonControlsOptions): void {
+    const prevHeight = opts.eyeHeight;
+    const prevGround = opts.groundZ;
+    opts = resolveOptions(opts, partial);
+    if (!stopped) host.style.cursor = opts.lookEnabled ? "crosshair" : "";
+    if (opts.eyeHeight !== prevHeight || opts.groundZ !== prevGround) {
+      cameraOrigin[2] = opts.groundZ + opts.eyeHeight;
+      syncTarget();
+    }
+  }
 
   return {
-    update(opts: GlyphFirstPersonControlsOptions): void {
-      drag = opts.drag ?? drag;
-      keyboard = opts.keyboard ?? keyboard;
-      moveSpeed = opts.moveSpeed ?? moveSpeed;
-      lookSpeed = opts.lookSpeed ?? lookSpeed;
-      invertFactor = resolveInvert(opts.invert);
+    update,
+    resume(): void {
+      if (!stopped) return;
+      stopped = false;
+      attach();
+      startLoop();
     },
-    pause(): void { if (stopped) return; stopped = true; detach(); activePointerId = null; },
-    resume(): void { if (!stopped) return; stopped = false; attach(); },
-    destroy(): void { if (!stopped) detach(); stopped = true; },
+    pause(): void {
+      if (stopped) return;
+      stopped = true;
+      detach();
+      stopLoop();
+    },
+    destroy(): void {
+      if (!stopped) { detach(); stopLoop(); }
+      stopped = true;
+    },
+    lock(): void {
+      if (!opts.enabled || !opts.lookEnabled || stopped) return;
+      try { host.requestPointerLock(); } catch { /* ignore */ }
+    },
+    unlock(): void {
+      if (pointerLocked) { try { doc.exitPointerLock(); } catch { /* ignore */ } }
+    },
+    isLocked(): boolean { return pointerLocked; },
+    getOrigin(): [number, number, number] {
+      return [cameraOrigin[0], cameraOrigin[1], cameraOrigin[2]];
+    },
+    setOrigin(origin: [number, number, number]): void {
+      cameraOrigin = [origin[0], origin[1], origin[2]];
+      syncTarget();
+    },
   };
-}
-
-function resolveInvert(invert: boolean | number | undefined): number {
-  if (invert === undefined || invert === false) return 1;
-  if (invert === true) return -1;
-  return invert;
 }

--- a/packages/glyphcss/src/api/createGlyphFirstPersonControls.ts
+++ b/packages/glyphcss/src/api/createGlyphFirstPersonControls.ts
@@ -20,6 +20,14 @@
 
 import type { GlyphSceneHandle } from "./createGlyphScene";
 import type { Vec3 } from "@glyphcss/core";
+import { makeListenerRegistry, makeCameraSnapshot, makeEventMethods, type GlyphControlsEventTarget } from "./controls/common";
+export type {
+  GlyphControlsCamera,
+  GlyphControlsChangeEvent,
+  GlyphControlsInteractionEvent,
+  GlyphControlsEvent,
+  GlyphControlsListener,
+} from "./controls/common";
 
 export interface GlyphFirstPersonControlsOptions {
   /** Master switch. When `false`, all sub-controls are inert. Default: `true`. */
@@ -110,7 +118,7 @@ function resolveOptions(base: ResolvedOptions, partial: GlyphFirstPersonControls
   };
 }
 
-export interface GlyphFirstPersonControlsHandle {
+export interface GlyphFirstPersonControlsHandle extends GlyphControlsEventTarget {
   update(partial: GlyphFirstPersonControlsOptions): void;
   resume(): void;
   pause(): void;
@@ -151,6 +159,10 @@ export function createGlyphFirstPersonControls(
   const doc = host.ownerDocument ?? document;
   const win = (doc.defaultView ?? globalThis) as typeof globalThis;
 
+  const registry = makeListenerRegistry();
+  const snapshot = makeCameraSnapshot(scene);
+  const { emitChange, emitInteraction } = registry;
+
   const keysHeld = new Set<string>();
   let pointerLocked = false;
   let stopped = false;
@@ -168,6 +180,7 @@ export function createGlyphFirstPersonControls(
   function syncTarget(): void {
     camera.target = [cameraOrigin[0], cameraOrigin[1], cameraOrigin[2]] as Vec3;
     scene.rerender();
+    emitChange(snapshot);
   }
 
   // On attach adopt the camera's current target (the orbit/pan visual center)
@@ -185,7 +198,10 @@ export function createGlyphFirstPersonControls(
   };
 
   const onPointerLockChange = (): void => {
-    pointerLocked = doc.pointerLockElement === host;
+    const locked = doc.pointerLockElement === host;
+    if (locked === pointerLocked) return;
+    pointerLocked = locked;
+    emitInteraction(locked ? "start" : "end", snapshot);
   };
 
   const onMouseMove = (e: MouseEvent): void => {
@@ -344,6 +360,7 @@ export function createGlyphFirstPersonControls(
   }
 
   return {
+    ...makeEventMethods(registry),
     update,
     resume(): void {
       if (!stopped) return;

--- a/packages/glyphcss/src/api/createGlyphMapControls.ts
+++ b/packages/glyphcss/src/api/createGlyphMapControls.ts
@@ -1,4 +1,4 @@
-// Vendored from voxcss packages/polycss/src/api/createPolyMapControls.ts@cac9da3. glyphcss deltas: Poly→Glyph rename; rotX/rotY in degrees (camera expects degrees); no common.ts dependency (inline helpers); no addEventListener/removeEventListener (not yet in glyphcss API surface); zoom clamp widened to absolute scale [0.1,500].
+// Vendored from voxcss packages/polycss/src/api/createPolyMapControls.ts@cac9da3. glyphcss deltas: Poly→Glyph rename; rotX/rotY in degrees (camera expects degrees); wheel/anim/options helpers inlined (controls/common.ts holds only the shared event registry); zoom clamp widened to absolute scale [0.1,500].
 /**
  * createGlyphMapControls — map/pan-mode camera input for a GlyphScene.
  *
@@ -13,6 +13,14 @@
 
 import type { GlyphSceneHandle } from "./createGlyphScene";
 import type { Vec3 } from "@glyphcss/core";
+import { makeListenerRegistry, makeCameraSnapshot, makeEventMethods, type GlyphControlsEventTarget } from "./controls/common";
+export type {
+  GlyphControlsCamera,
+  GlyphControlsChangeEvent,
+  GlyphControlsInteractionEvent,
+  GlyphControlsEvent,
+  GlyphControlsListener,
+} from "./controls/common";
 
 export interface GlyphMapControlsOptions {
   drag?: boolean;
@@ -21,7 +29,7 @@ export interface GlyphMapControlsOptions {
   animate?: false | { speed?: number; axis?: "x" | "y"; pauseOnInteraction?: boolean };
 }
 
-export interface GlyphMapControlsHandle {
+export interface GlyphMapControlsHandle extends GlyphControlsEventTarget {
   update(opts: GlyphMapControlsOptions): void;
   pause(): void;
   resume(): void;
@@ -46,6 +54,11 @@ export function createGlyphMapControls(
   let rightDown = false;
 
   const camera = scene.camera;
+  const registry = makeListenerRegistry();
+  const snapshot = makeCameraSnapshot(scene);
+  const { emitChange, emitInteraction } = registry;
+  let wheelActive = false;
+  let wheelIdleTimer: ReturnType<typeof setTimeout> | null = null;
   // rotX/rotY are in degrees — drag sensitivity: 4 px per degree (POINTER_DRAG_SPEED = 4).
   const DEG_PER_PX = 1 / 4;
   const PAN_SCALE = 0.02;
@@ -63,6 +76,7 @@ export function createGlyphMapControls(
     if (animOpts && (animOpts as { pauseOnInteraction?: boolean }).pauseOnInteraction !== false) {
       animPaused = true;
     }
+    emitInteraction("start", snapshot);
   }
 
   function onPointerMove(e: PointerEvent): void {
@@ -88,6 +102,7 @@ export function createGlyphMapControls(
       ] as Vec3;
     }
     scene.rerender();
+    emitChange(snapshot);
   }
 
   function onPointerUp(e: PointerEvent): void {
@@ -97,6 +112,7 @@ export function createGlyphMapControls(
     host.style.cursor = drag && !stopped ? "grab" : "";
     try { (e.target as Element).releasePointerCapture(e.pointerId); } catch { /* ignore */ }
     if (animOpts) animPaused = false;
+    emitInteraction("end", snapshot);
   }
 
   function onContextMenu(e: Event): void { e.preventDefault(); }
@@ -109,6 +125,14 @@ export function createGlyphMapControls(
     // and deep zoom both work. Was [0.05, 10] under the old fraction scale.
     camera.zoom = Math.max(0.1, Math.min(500, camera.zoom * (1 - delta)));
     scene.rerender();
+    if (!wheelActive) { wheelActive = true; emitInteraction("start", snapshot); }
+    emitChange(snapshot);
+    if (wheelIdleTimer !== null) clearTimeout(wheelIdleTimer);
+    wheelIdleTimer = setTimeout(() => {
+      wheelIdleTimer = null;
+      wheelActive = false;
+      emitInteraction("end", snapshot);
+    }, 150);
   }
 
   function animTick(time: number): void {
@@ -122,6 +146,7 @@ export function createGlyphMapControls(
       if (axis === "y") camera.rotY = camera.rotY + dAngle;
       else camera.rotX = camera.rotX + dAngle;
       scene.rerender();
+      emitChange(snapshot);
     }
     lastTime = time;
     rafId = requestAnimationFrame(animTick);
@@ -163,10 +188,16 @@ export function createGlyphMapControls(
     host.style.userSelect = "";
   }
 
+  function clearWheelIdle(): void {
+    if (wheelIdleTimer !== null) { clearTimeout(wheelIdleTimer); wheelIdleTimer = null; }
+    wheelActive = false;
+  }
+
   attach();
   startAnim();
 
   return {
+    ...makeEventMethods(registry),
     update(opts: GlyphMapControlsOptions): void {
       const wasAnimating = !!animOpts;
       drag = opts.drag ?? drag;
@@ -178,9 +209,9 @@ export function createGlyphMapControls(
       if (wasAnimating && !isAnimating) stopAnim();
       else if (!wasAnimating && isAnimating) startAnim();
     },
-    pause(): void { if (stopped) return; stopped = true; detach(); stopAnim(); activePointerId = null; animPaused = false; },
+    pause(): void { if (stopped) return; stopped = true; detach(); stopAnim(); clearWheelIdle(); activePointerId = null; animPaused = false; },
     resume(): void { if (!stopped) return; stopped = false; attach(); startAnim(); },
-    destroy(): void { if (!stopped) detach(); stopAnim(); stopped = true; },
+    destroy(): void { if (!stopped) detach(); stopAnim(); clearWheelIdle(); stopped = true; },
   };
 }
 

--- a/packages/glyphcss/src/api/createGlyphOrbitControls.test.ts
+++ b/packages/glyphcss/src/api/createGlyphOrbitControls.test.ts
@@ -293,3 +293,58 @@ describe("createGlyphOrbitControls", () => {
     controls.destroy();
   });
 });
+
+describe("createGlyphOrbitControls — events", () => {
+  let scene: GlyphSceneHandle;
+  beforeEach(() => { scene = makeScene(); });
+  afterEach(() => { scene.destroy(); });
+
+  it("exposes addEventListener / removeEventListener / hasEventListener", () => {
+    const c = createGlyphOrbitControls(scene);
+    expect(typeof c.addEventListener).toBe("function");
+    expect(typeof c.removeEventListener).toBe("function");
+    expect(typeof c.hasEventListener).toBe("function");
+    c.destroy();
+  });
+
+  it("emits 'change' on drag with a camera snapshot", () => {
+    const c = createGlyphOrbitControls(scene);
+    const events: unknown[] = [];
+    const fn = (e: { type: string; camera: { rotY: number } }) => events.push(e);
+    c.addEventListener("change", fn);
+    expect(c.hasEventListener("change", fn)).toBe(true);
+    pd(scene.host, 100, 100);
+    pm(scene.host, 160, 100);
+    pu(scene.host);
+    expect(events.length).toBeGreaterThan(0);
+    expect((events[0] as { type: string }).type).toBe("change");
+    expect(typeof (events[0] as { camera: { rotY: number } }).camera.rotY).toBe("number");
+    c.removeEventListener("change", fn);
+    expect(c.hasEventListener("change", fn)).toBe(false);
+    c.destroy();
+  });
+
+  it("emits 'start' on pointerdown and 'end' on pointerup", () => {
+    const c = createGlyphOrbitControls(scene);
+    const types: string[] = [];
+    c.addEventListener("start", () => types.push("start"));
+    c.addEventListener("end", () => types.push("end"));
+    pd(scene.host, 100, 100);
+    pu(scene.host);
+    expect(types).toEqual(["start", "end"]);
+    c.destroy();
+  });
+
+  it("removeEventListener stops delivery", () => {
+    const c = createGlyphOrbitControls(scene);
+    let n = 0;
+    const fn = () => { n += 1; };
+    c.addEventListener("change", fn);
+    pd(scene.host, 100, 100); pm(scene.host, 150, 100);
+    const after = n;
+    c.removeEventListener("change", fn);
+    pm(scene.host, 200, 100); pu(scene.host);
+    expect(n).toBe(after);
+    c.destroy();
+  });
+});

--- a/packages/glyphcss/src/api/createGlyphOrbitControls.ts
+++ b/packages/glyphcss/src/api/createGlyphOrbitControls.ts
@@ -1,4 +1,4 @@
-// Vendored from voxcss packages/polycss/src/api/createPolyOrbitControls.ts@cac9da3. glyphcss deltas: Poly→Glyph rename; rotX/rotY in degrees (camera expects degrees); no common.ts dependency (inline helpers); no addEventListener/removeEventListener (not yet in glyphcss API surface); zoom clamp widened to absolute scale [0.1,500].
+// Vendored from voxcss packages/polycss/src/api/createPolyOrbitControls.ts@cac9da3. glyphcss deltas: Poly→Glyph rename; rotX/rotY in degrees (camera expects degrees); wheel/anim/options helpers inlined (controls/common.ts holds only the shared event registry); zoom clamp widened to absolute scale [0.1,500].
 /**
  * createGlyphOrbitControls — orbit-mode camera input for a GlyphScene.
  *
@@ -12,6 +12,14 @@
  */
 
 import type { GlyphSceneHandle } from "./createGlyphScene";
+import { makeListenerRegistry, makeCameraSnapshot, makeEventMethods, type GlyphControlsEventTarget } from "./controls/common";
+export type {
+  GlyphControlsCamera,
+  GlyphControlsChangeEvent,
+  GlyphControlsInteractionEvent,
+  GlyphControlsEvent,
+  GlyphControlsListener,
+} from "./controls/common";
 
 export interface GlyphOrbitControlsOptions {
   /** Pointer-drag. Default: true. */
@@ -30,7 +38,7 @@ export interface GlyphOrbitControlsOptions {
   animate?: false | { speed?: number; axis?: "x" | "y"; pauseOnInteraction?: boolean };
 }
 
-export interface GlyphOrbitControlsHandle {
+export interface GlyphOrbitControlsHandle extends GlyphControlsEventTarget {
   update(opts: GlyphOrbitControlsOptions): void;
   pause(): void;
   resume(): void;
@@ -56,6 +64,11 @@ export function createGlyphOrbitControls(
   let pointer = { x: 0, y: 0 };
 
   const camera = scene.camera;
+  const registry = makeListenerRegistry();
+  const snapshot = makeCameraSnapshot(scene);
+  const { emitChange, emitInteraction } = registry;
+  let wheelActive = false;
+  let wheelIdleTimer: ReturnType<typeof setTimeout> | null = null;
 
   function onPointerDown(e: PointerEvent): void {
     if (!drag || stopped) return;
@@ -69,6 +82,7 @@ export function createGlyphOrbitControls(
     if (animOpts && (animOpts as { pauseOnInteraction?: boolean }).pauseOnInteraction !== false) {
       animPaused = true;
     }
+    emitInteraction("start", snapshot);
   }
 
   function onPointerMove(e: PointerEvent): void {
@@ -89,6 +103,7 @@ export function createGlyphOrbitControls(
     const nextRotX = camera.rotX - dy * DEG_PER_PX * f;
     camera.rotX = clampPitch ? Math.max(-90, Math.min(90, nextRotX)) : nextRotX;
     scene.rerender();
+    emitChange(snapshot);
   }
 
   function onPointerUp(e: PointerEvent): void {
@@ -97,6 +112,7 @@ export function createGlyphOrbitControls(
     host.style.cursor = drag && !stopped ? "grab" : "";
     try { (e.target as Element).releasePointerCapture(e.pointerId); } catch { /* ignore */ }
     if (animOpts) animPaused = false;
+    emitInteraction("end", snapshot);
   }
 
   function onWheel(e: WheelEvent): void {
@@ -108,6 +124,14 @@ export function createGlyphOrbitControls(
     // div-by-zero, a high ceiling for deep zoom.
     camera.zoom = Math.max(0.1, Math.min(500, camera.zoom * (1 - delta)));
     scene.rerender();
+    if (!wheelActive) { wheelActive = true; emitInteraction("start", snapshot); }
+    emitChange(snapshot);
+    if (wheelIdleTimer !== null) clearTimeout(wheelIdleTimer);
+    wheelIdleTimer = setTimeout(() => {
+      wheelIdleTimer = null;
+      wheelActive = false;
+      emitInteraction("end", snapshot);
+    }, 150);
   }
 
   function animTick(time: number): void {
@@ -121,6 +145,7 @@ export function createGlyphOrbitControls(
       if (axis === "y") camera.rotY = camera.rotY + dAngle;
       else camera.rotX = camera.rotX + dAngle;
       scene.rerender();
+      emitChange(snapshot);
     }
     lastTime = time;
     rafId = requestAnimationFrame(animTick);
@@ -163,10 +188,16 @@ export function createGlyphOrbitControls(
     host.style.userSelect = "";
   }
 
+  function clearWheelIdle(): void {
+    if (wheelIdleTimer !== null) { clearTimeout(wheelIdleTimer); wheelIdleTimer = null; }
+    wheelActive = false;
+  }
+
   attach();
   startAnim();
 
   return {
+    ...makeEventMethods(registry),
     update(opts: GlyphOrbitControlsOptions): void {
       const wasAnimating = !!animOpts;
       drag = opts.drag ?? drag;
@@ -186,6 +217,7 @@ export function createGlyphOrbitControls(
       stopped = true;
       detach();
       stopAnim();
+      clearWheelIdle();
       activePointerId = null;
       animPaused = false;
     },
@@ -198,6 +230,7 @@ export function createGlyphOrbitControls(
     destroy(): void {
       if (!stopped) detach();
       stopAnim();
+      clearWheelIdle();
       stopped = true;
     },
   };

--- a/packages/glyphcss/src/elements.ts
+++ b/packages/glyphcss/src/elements.ts
@@ -16,6 +16,7 @@ import { GlyphPerspectiveCameraElement } from "./elements/GlyphPerspectiveCamera
 import { GlyphOrthographicCameraElement } from "./elements/GlyphOrthographicCameraElement";
 import { GlyphOrbitControlsElement } from "./elements/GlyphOrbitControlsElement";
 import { GlyphMapControlsElement } from "./elements/GlyphMapControlsElement";
+import { GlyphFirstPersonControlsElement } from "./elements/GlyphFirstPersonControlsElement";
 
 if (typeof customElements !== "undefined") {
   if (!customElements.get("glyph-scene")) {
@@ -47,6 +48,9 @@ if (typeof customElements !== "undefined") {
   if (!customElements.get("glyph-map-controls")) {
     customElements.define("glyph-map-controls", GlyphMapControlsElement);
   }
+  if (!customElements.get("glyph-first-person-controls")) {
+    customElements.define("glyph-first-person-controls", GlyphFirstPersonControlsElement);
+  }
 }
 
 export {
@@ -57,4 +61,5 @@ export {
   GlyphOrthographicCameraElement,
   GlyphOrbitControlsElement,
   GlyphMapControlsElement,
+  GlyphFirstPersonControlsElement,
 };

--- a/packages/glyphcss/src/elements/GlyphFirstPersonControlsElement.test.ts
+++ b/packages/glyphcss/src/elements/GlyphFirstPersonControlsElement.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { GlyphSceneElement } from "./GlyphSceneElement";
+import { GlyphFirstPersonControlsElement } from "./GlyphFirstPersonControlsElement";
+import { GlyphPerspectiveCameraElement } from "./GlyphPerspectiveCameraElement";
+
+if (!customElements.get("glyph-scene")) {
+  customElements.define("glyph-scene", GlyphSceneElement);
+}
+if (!customElements.get("glyph-first-person-controls")) {
+  customElements.define("glyph-first-person-controls", GlyphFirstPersonControlsElement);
+}
+if (!customElements.get("glyph-perspective-camera")) {
+  customElements.define("glyph-perspective-camera", GlyphPerspectiveCameraElement);
+}
+
+describe("GlyphFirstPersonControlsElement", () => {
+  let camEl: GlyphPerspectiveCameraElement;
+  let sceneEl: GlyphSceneElement;
+  let controls: GlyphFirstPersonControlsElement;
+
+  beforeEach(() => {
+    camEl = document.createElement("glyph-perspective-camera") as GlyphPerspectiveCameraElement;
+    sceneEl = document.createElement("glyph-scene") as GlyphSceneElement;
+    sceneEl.setAttribute("cols", "20");
+    sceneEl.setAttribute("rows", "5");
+    camEl.appendChild(sceneEl);
+    document.body.appendChild(camEl);
+    controls = document.createElement("glyph-first-person-controls") as GlyphFirstPersonControlsElement;
+  });
+
+  afterEach(() => {
+    if (controls.isConnected) controls.remove();
+    if (camEl.isConnected) camEl.remove();
+  });
+
+  it("is registered under the 'glyph-first-person-controls' tag", () => {
+    expect(customElements.get("glyph-first-person-controls")).toBe(GlyphFirstPersonControlsElement);
+  });
+
+  it("createElement produces a GlyphFirstPersonControlsElement instance", () => {
+    expect(controls).toBeInstanceOf(GlyphFirstPersonControlsElement);
+  });
+
+  it("declares the documented observed attributes", () => {
+    const attrs = GlyphFirstPersonControlsElement.observedAttributes;
+    for (const a of ["look-enabled", "move-enabled", "jump-enabled", "crouch-enabled", "move-speed", "eye-height", "look-sensitivity"]) {
+      expect(attrs).toContain(a);
+    }
+  });
+
+  it("connects without throwing inside a perspective scene", () => {
+    expect(() => { sceneEl.appendChild(controls); }).not.toThrow();
+  });
+
+  it("no-ops (does not throw) when connected outside a scene", () => {
+    expect(() => { document.body.appendChild(controls); }).not.toThrow();
+    controls.remove();
+  });
+
+  it("disconnectedCallback cleans up without throwing", () => {
+    sceneEl.appendChild(controls);
+    expect(() => { controls.remove(); }).not.toThrow();
+  });
+});

--- a/packages/glyphcss/src/elements/GlyphFirstPersonControlsElement.ts
+++ b/packages/glyphcss/src/elements/GlyphFirstPersonControlsElement.ts
@@ -1,0 +1,135 @@
+/**
+ * `<glyph-first-person-controls>` — declarative first-person controls.
+ *
+ * Behavior element (no rendered output). Sits inside <glyph-scene> and attaches
+ * to the parent scene. The full createGlyphFirstPersonControls option surface is
+ * exposed via kebab-case attributes:
+ *
+ *   <glyph-first-person-controls
+ *     enabled look-enabled move-enabled jump-enabled crouch-enabled
+ *     look-sensitivity="0.2" invert-y move-speed="8" jump-velocity="10"
+ *     gravity="20" eye-height="1.7" crouch-height="1" ground-z="0"
+ *     min-pitch="5" max-pitch="175"
+ *   ></glyph-first-person-controls>
+ *
+ * Requires a perspective camera (see createGlyphFirstPersonControls).
+ */
+import {
+  createGlyphFirstPersonControls,
+  type GlyphFirstPersonControlsHandle,
+  type GlyphFirstPersonControlsOptions,
+} from "../api/createGlyphFirstPersonControls";
+import type { GlyphSceneElement } from "./GlyphSceneElement";
+
+const ELEMENT_BASE: typeof HTMLElement =
+  typeof HTMLElement !== "undefined"
+    ? HTMLElement
+    : (class {} as unknown as typeof HTMLElement);
+
+function parseNumber(value: string | null): number | undefined {
+  if (value == null) return undefined;
+  const n = parseFloat(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function parseBool(value: string | null): boolean | undefined {
+  if (value === null) return undefined;
+  if (value === "false") return false;
+  if (value === "true" || value === "") return true;
+  return undefined;
+}
+
+function findScene(el: HTMLElement): GlyphSceneElement | null {
+  const found = el.closest("glyph-scene") as unknown as GlyphSceneElement | null;
+  return found ?? null;
+}
+
+const OBSERVED_ATTRS = [
+  "enabled",
+  "look-enabled",
+  "move-enabled",
+  "jump-enabled",
+  "crouch-enabled",
+  "look-sensitivity",
+  "invert-y",
+  "move-speed",
+  "jump-velocity",
+  "gravity",
+  "eye-height",
+  "crouch-height",
+  "ground-z",
+  "min-pitch",
+  "max-pitch",
+] as const;
+
+export class GlyphFirstPersonControlsElement extends ELEMENT_BASE {
+  static get observedAttributes(): string[] {
+    return [...OBSERVED_ATTRS];
+  }
+
+  private _controls: GlyphFirstPersonControlsHandle | null = null;
+
+  connectedCallback(): void { this._attach(); }
+
+  disconnectedCallback(): void {
+    if (this._controls) { this._controls.destroy(); this._controls = null; }
+  }
+
+  attributeChangedCallback(_name: string, old: string | null, next: string | null): void {
+    if (old === next) return;
+    this._controls?.update(this._readOptions());
+  }
+
+  private _readOptions(): GlyphFirstPersonControlsOptions {
+    const opts: GlyphFirstPersonControlsOptions = {};
+    const enabled = parseBool(this.getAttribute("enabled"));
+    if (enabled !== undefined) opts.enabled = enabled;
+    const lookEnabled = parseBool(this.getAttribute("look-enabled"));
+    if (lookEnabled !== undefined) opts.lookEnabled = lookEnabled;
+    const moveEnabled = parseBool(this.getAttribute("move-enabled"));
+    if (moveEnabled !== undefined) opts.moveEnabled = moveEnabled;
+    const jumpEnabled = parseBool(this.getAttribute("jump-enabled"));
+    if (jumpEnabled !== undefined) opts.jumpEnabled = jumpEnabled;
+    const crouchEnabled = parseBool(this.getAttribute("crouch-enabled"));
+    if (crouchEnabled !== undefined) opts.crouchEnabled = crouchEnabled;
+    const lookSensitivity = parseNumber(this.getAttribute("look-sensitivity"));
+    if (lookSensitivity !== undefined) opts.lookSensitivity = lookSensitivity;
+    if (this.hasAttribute("invert-y")) {
+      const invertY = parseBool(this.getAttribute("invert-y"));
+      if (invertY !== undefined) opts.invertY = invertY;
+    }
+    const moveSpeed = parseNumber(this.getAttribute("move-speed"));
+    if (moveSpeed !== undefined) opts.moveSpeed = moveSpeed;
+    const jumpVelocity = parseNumber(this.getAttribute("jump-velocity"));
+    if (jumpVelocity !== undefined) opts.jumpVelocity = jumpVelocity;
+    const gravity = parseNumber(this.getAttribute("gravity"));
+    if (gravity !== undefined) opts.gravity = gravity;
+    const eyeHeight = parseNumber(this.getAttribute("eye-height"));
+    if (eyeHeight !== undefined) opts.eyeHeight = eyeHeight;
+    const crouchHeight = parseNumber(this.getAttribute("crouch-height"));
+    if (crouchHeight !== undefined) opts.crouchHeight = crouchHeight;
+    const groundZ = parseNumber(this.getAttribute("ground-z"));
+    if (groundZ !== undefined) opts.groundZ = groundZ;
+    const minPitch = parseNumber(this.getAttribute("min-pitch"));
+    if (minPitch !== undefined) opts.minPitch = minPitch;
+    const maxPitch = parseNumber(this.getAttribute("max-pitch"));
+    if (maxPitch !== undefined) opts.maxPitch = maxPitch;
+    return opts;
+  }
+
+  private _attach(): void {
+    if (this._controls) return;
+    const sceneEl = findScene(this);
+    if (!sceneEl) return;
+    const handle = sceneEl.getScene();
+    if (!handle) {
+      const onReady = (): void => {
+        sceneEl.removeEventListener("glyphcss:scene-ready", onReady);
+        this._attach();
+      };
+      sceneEl.addEventListener("glyphcss:scene-ready", onReady);
+      return;
+    }
+    this._controls = createGlyphFirstPersonControls(handle, this._readOptions());
+  }
+}

--- a/packages/glyphcss/src/index.ts
+++ b/packages/glyphcss/src/index.ts
@@ -62,6 +62,17 @@ export type {
   GlyphFirstPersonControlsHandle,
 } from "./api/createGlyphFirstPersonControls";
 
+// Shared controls event surface (change / start / end), exposed on every
+// control handle's addEventListener — parity with voxcss PolyControls* events.
+export type {
+  GlyphControlsCamera,
+  GlyphControlsChangeEvent,
+  GlyphControlsInteractionEvent,
+  GlyphControlsEvent,
+  GlyphControlsListener,
+  GlyphControlsEventTarget,
+} from "./api/controls/common";
+
 // ── Mesh finders ──────────────────────────────────────────────────
 export { findGlyphMeshHandle, findMeshUnderPoint, pointInMeshElement } from "./api/meshFinders";
 

--- a/packages/react/src/glyphcss/controls/GlyphFirstPersonControls.test.tsx
+++ b/packages/react/src/glyphcss/controls/GlyphFirstPersonControls.test.tsx
@@ -42,24 +42,24 @@ describe("GlyphFirstPersonControls — mount inside scene", () => {
     expect(container.querySelector(".glyph-host")).toBeTruthy();
   });
 
-  it("accepts drag=false without throwing", () => {
-    expect(() => renderScene({ drag: false })).not.toThrow();
+  it("accepts lookEnabled=false without throwing", () => {
+    expect(() => renderScene({ lookEnabled: false })).not.toThrow();
   });
 
-  it("accepts keyboard=false without throwing", () => {
-    expect(() => renderScene({ keyboard: false })).not.toThrow();
+  it("accepts moveEnabled=false without throwing", () => {
+    expect(() => renderScene({ moveEnabled: false })).not.toThrow();
   });
 
-  it("accepts custom moveSpeed and lookSpeed", () => {
-    expect(() => renderScene({ moveSpeed: 0.1, lookSpeed: 0.01 })).not.toThrow();
+  it("accepts custom moveSpeed and lookSensitivity", () => {
+    expect(() => renderScene({ moveSpeed: 0.1, lookSensitivity: 0.01 })).not.toThrow();
   });
 
-  it("accepts invert=true", () => {
-    expect(() => renderScene({ invert: true })).not.toThrow();
+  it("accepts invertY=true", () => {
+    expect(() => renderScene({ invertY: true })).not.toThrow();
   });
 
   it("updates props without throwing", () => {
-    const { container, root } = renderScene({ drag: true, keyboard: true });
+    const { container, root } = renderScene({ lookEnabled: true, moveEnabled: true });
     act(() =>
       root.render(
         React.createElement(
@@ -68,7 +68,7 @@ describe("GlyphFirstPersonControls — mount inside scene", () => {
           React.createElement(
             GlyphScene,
             {},
-            React.createElement(GlyphFirstPersonControls, { drag: false, keyboard: false }),
+            React.createElement(GlyphFirstPersonControls, { lookEnabled: false, moveEnabled: false }),
           ),
         ),
       ),

--- a/packages/react/src/glyphcss/controls/GlyphFirstPersonControls.tsx
+++ b/packages/react/src/glyphcss/controls/GlyphFirstPersonControls.tsx
@@ -1,6 +1,7 @@
 /**
  * GlyphFirstPersonControls — first-person controls for an ASCII GlyphScene.
- * Pointer-drag looks around; WASD / arrow keys move.
+ * Pointer-lock mouselook, WASD/arrow planar move, Space jump, Ctrl crouch.
+ * Mirrors voxcss PolyFirstPersonControls.
  */
 import { useEffect, useRef } from "react";
 import type { GlyphFirstPersonControlsHandle, GlyphFirstPersonControlsOptions } from "glyphcss";
@@ -8,36 +9,33 @@ import { createGlyphFirstPersonControls } from "glyphcss";
 import { useGlyphSceneContext } from "../scene/context";
 
 export interface GlyphFirstPersonControlsProps {
-  drag?: boolean;
-  keyboard?: boolean;
+  enabled?: boolean;
+  lookEnabled?: boolean;
+  moveEnabled?: boolean;
+  jumpEnabled?: boolean;
+  crouchEnabled?: boolean;
+  lookSensitivity?: number;
+  invertY?: boolean;
   moveSpeed?: number;
-  lookSpeed?: number;
-  invert?: boolean | number;
+  jumpVelocity?: number;
+  gravity?: number;
+  eyeHeight?: number;
+  crouchHeight?: number;
+  groundZ?: number;
+  minPitch?: number;
+  maxPitch?: number;
 }
 
-export function GlyphFirstPersonControls({
-  drag = true,
-  keyboard = true,
-  moveSpeed = 0.05,
-  lookSpeed = 0.004,
-  invert = false,
-}: GlyphFirstPersonControlsProps): null {
+export function GlyphFirstPersonControls(props: GlyphFirstPersonControlsProps): null {
   const { sceneRef } = useGlyphSceneContext();
   const controlsRef = useRef<GlyphFirstPersonControlsHandle | null>(null);
-  const propsRef = useRef({ drag, keyboard, moveSpeed, lookSpeed, invert });
-  propsRef.current = { drag, keyboard, moveSpeed, lookSpeed, invert };
+  const propsRef = useRef(props);
+  propsRef.current = props;
 
   useEffect(() => {
     const scene = sceneRef.current;
     if (!scene) return;
-    const opts: GlyphFirstPersonControlsOptions = {
-      drag: propsRef.current.drag,
-      keyboard: propsRef.current.keyboard,
-      moveSpeed: propsRef.current.moveSpeed,
-      lookSpeed: propsRef.current.lookSpeed,
-      invert: propsRef.current.invert,
-    };
-    const controls = createGlyphFirstPersonControls(scene, opts);
+    const controls = createGlyphFirstPersonControls(scene, propsRef.current as GlyphFirstPersonControlsOptions);
     controlsRef.current = controls;
     return () => {
       controls.destroy();
@@ -46,9 +44,7 @@ export function GlyphFirstPersonControls({
   }, [sceneRef]);
 
   useEffect(() => {
-    const controls = controlsRef.current;
-    if (!controls) return;
-    controls.update({ drag, keyboard, moveSpeed, lookSpeed, invert });
+    controlsRef.current?.update(props as GlyphFirstPersonControlsOptions);
   });
 
   return null;

--- a/packages/vue/src/glyphcss/controls/GlyphFirstPersonControls.test.ts
+++ b/packages/vue/src/glyphcss/controls/GlyphFirstPersonControls.test.ts
@@ -5,11 +5,11 @@ import { GlyphPerspectiveCamera } from "../camera/GlyphPerspectiveCamera";
 import { GlyphFirstPersonControls } from "./GlyphFirstPersonControls";
 
 type FPControlsProps = {
-  drag?: boolean;
-  keyboard?: boolean;
+  lookEnabled?: boolean;
+  moveEnabled?: boolean;
   moveSpeed?: number;
-  lookSpeed?: number;
-  invert?: boolean | number;
+  lookSensitivity?: number;
+  invertY?: boolean;
 };
 
 function renderScene(
@@ -48,23 +48,23 @@ describe("GlyphFirstPersonControls (Vue) — mount inside scene", () => {
     expect(container.querySelector(".glyph-host")).toBeTruthy();
   });
 
-  it("accepts drag=false without throwing", () => {
-    expect(() => renderScene({ drag: false })).not.toThrow();
+  it("accepts lookEnabled=false without throwing", () => {
+    expect(() => renderScene({ lookEnabled: false })).not.toThrow();
   });
 
-  it("accepts keyboard=false without throwing", () => {
-    expect(() => renderScene({ keyboard: false })).not.toThrow();
+  it("accepts moveEnabled=false without throwing", () => {
+    expect(() => renderScene({ moveEnabled: false })).not.toThrow();
   });
 
-  it("accepts custom moveSpeed and lookSpeed", () => {
-    expect(() => renderScene({ moveSpeed: 0.1, lookSpeed: 0.01 })).not.toThrow();
+  it("accepts custom moveSpeed and lookSensitivity", () => {
+    expect(() => renderScene({ moveSpeed: 0.1, lookSensitivity: 0.01 })).not.toThrow();
   });
 
-  it("accepts invert=true", () => {
-    expect(() => renderScene({ invert: true })).not.toThrow();
+  it("accepts invertY=true", () => {
+    expect(() => renderScene({ invertY: true })).not.toThrow();
   });
 
-  it("reacts to drag prop change", async () => {
+  it("reacts to lookEnabled prop change", async () => {
     const drag = ref(true);
     const container = document.createElement("div");
     document.body.appendChild(container);
@@ -74,7 +74,7 @@ describe("GlyphFirstPersonControls (Vue) — mount inside scene", () => {
           h(GlyphPerspectiveCamera, {}, {
             default: () =>
               h(GlyphScene, {}, {
-                default: () => h(GlyphFirstPersonControls, { drag: drag.value }),
+                default: () => h(GlyphFirstPersonControls, { lookEnabled: drag.value }),
               }),
           });
       },

--- a/packages/vue/src/glyphcss/controls/GlyphFirstPersonControls.ts
+++ b/packages/vue/src/glyphcss/controls/GlyphFirstPersonControls.ts
@@ -1,5 +1,7 @@
 /**
  * GlyphFirstPersonControls — Vue 3 first-person controls for GlyphScene.
+ * Pointer-lock mouselook, WASD/arrow planar move, Space jump, Ctrl crouch.
+ * Mirrors voxcss PolyFirstPersonControls.
  */
 import { defineComponent, inject, onBeforeUnmount, watch, shallowRef, watchEffect } from "vue";
 import type { GlyphFirstPersonControlsHandle, GlyphFirstPersonControlsOptions } from "glyphcss";
@@ -7,21 +9,41 @@ import { createGlyphFirstPersonControls } from "glyphcss";
 import { GlyphSceneContextKey } from "../scene/context";
 
 export interface GlyphFirstPersonControlsProps {
-  drag?: boolean;
-  keyboard?: boolean;
+  enabled?: boolean;
+  lookEnabled?: boolean;
+  moveEnabled?: boolean;
+  jumpEnabled?: boolean;
+  crouchEnabled?: boolean;
+  lookSensitivity?: number;
+  invertY?: boolean;
   moveSpeed?: number;
-  lookSpeed?: number;
-  invert?: boolean | number;
+  jumpVelocity?: number;
+  gravity?: number;
+  eyeHeight?: number;
+  crouchHeight?: number;
+  groundZ?: number;
+  minPitch?: number;
+  maxPitch?: number;
 }
 
 export const GlyphFirstPersonControls = defineComponent({
   name: "GlyphFirstPersonControls",
   props: {
-    drag: { type: Boolean, default: true },
-    keyboard: { type: Boolean, default: true },
-    moveSpeed: { type: Number, default: 0.05 },
-    lookSpeed: { type: Number, default: 0.004 },
-    invert: { type: [Boolean, Number] as unknown as () => boolean | number, default: false },
+    enabled: { type: Boolean, default: undefined },
+    lookEnabled: { type: Boolean, default: undefined },
+    moveEnabled: { type: Boolean, default: undefined },
+    jumpEnabled: { type: Boolean, default: undefined },
+    crouchEnabled: { type: Boolean, default: undefined },
+    lookSensitivity: { type: Number, default: undefined },
+    invertY: { type: Boolean, default: undefined },
+    moveSpeed: { type: Number, default: undefined },
+    jumpVelocity: { type: Number, default: undefined },
+    gravity: { type: Number, default: undefined },
+    eyeHeight: { type: Number, default: undefined },
+    crouchHeight: { type: Number, default: undefined },
+    groundZ: { type: Number, default: undefined },
+    minPitch: { type: Number, default: undefined },
+    maxPitch: { type: Number, default: undefined },
   },
   setup(props) {
     const sceneCtx = inject(GlyphSceneContextKey);
@@ -31,19 +53,30 @@ export const GlyphFirstPersonControls = defineComponent({
     const { sceneRef } = sceneCtx;
     const controlsRef = shallowRef<GlyphFirstPersonControlsHandle | null>(null);
 
+    const optsFromProps = (): GlyphFirstPersonControlsOptions => ({
+      enabled: props.enabled,
+      lookEnabled: props.lookEnabled,
+      moveEnabled: props.moveEnabled,
+      jumpEnabled: props.jumpEnabled,
+      crouchEnabled: props.crouchEnabled,
+      lookSensitivity: props.lookSensitivity,
+      invertY: props.invertY,
+      moveSpeed: props.moveSpeed,
+      jumpVelocity: props.jumpVelocity,
+      gravity: props.gravity,
+      eyeHeight: props.eyeHeight,
+      crouchHeight: props.crouchHeight,
+      groundZ: props.groundZ,
+      minPitch: props.minPitch,
+      maxPitch: props.maxPitch,
+    });
+
     // In Vue 3, child onMounted hooks fire before parent onMounted, so
     // sceneRef.value is null when this runs. Watch for the scene to appear.
     const stopWatch = watchEffect(() => {
       const scene = sceneRef.value;
       if (!scene || controlsRef.value) return;
-      const opts: GlyphFirstPersonControlsOptions = {
-        drag: props.drag,
-        keyboard: props.keyboard,
-        moveSpeed: props.moveSpeed,
-        lookSpeed: props.lookSpeed,
-        invert: props.invert,
-      };
-      controlsRef.value = createGlyphFirstPersonControls(scene, opts);
+      controlsRef.value = createGlyphFirstPersonControls(scene, optsFromProps());
     });
 
     onBeforeUnmount(() => {
@@ -52,12 +85,9 @@ export const GlyphFirstPersonControls = defineComponent({
       controlsRef.value = null;
     });
 
-    watch(
-      () => ({ drag: props.drag, keyboard: props.keyboard, moveSpeed: props.moveSpeed, lookSpeed: props.lookSpeed, invert: props.invert }),
-      (next) => {
-        controlsRef.value?.update(next);
-      },
-    );
+    watch(optsFromProps, (next) => {
+      controlsRef.value?.update(next);
+    });
 
     return () => null;
   },

--- a/website/src/content/docs/api/html.mdx
+++ b/website/src/content/docs/api/html.mdx
@@ -122,6 +122,20 @@ target plane.
 | `animate-speed` | Orbit-only: auto-rotation speed |
 | `animate-axis` | Orbit-only: `x` \| `y` \| `z` |
 
+### `<glyph-first-person-controls>`
+
+First-person camera (requires a `<glyph-perspective-camera>`). Pointer-lock
+mouselook, WASD/arrow move, Space jump, Ctrl crouch.
+
+| Attribute | Notes |
+|---|---|
+| `look-enabled` / `move-enabled` / `jump-enabled` / `crouch-enabled` | flags — toggle each axis |
+| `look-sensitivity` | degrees per pixel (default `0.15`) |
+| `invert-y` | flag — invert vertical look |
+| `move-speed` / `jump-velocity` / `gravity` | world-unit motion params |
+| `eye-height` / `crouch-height` / `ground-z` | world-unit placement |
+| `min-pitch` / `max-pitch` | pitch clamp (degrees) |
+
 ## Scene-ready handshake
 
 Custom elements register asynchronously. If you need to call imperative

--- a/website/src/content/docs/components/glyph-controls.mdx
+++ b/website/src/content/docs/components/glyph-controls.mdx
@@ -13,7 +13,7 @@ component wraps the scene.
 |---|---|---|
 | `GlyphOrbitControls` | Left-drag orbits; wheel zooms | General-purpose — object inspection |
 | `GlyphMapControls` | Left-drag pans; right-drag / Shift+left orbits; wheel zooms | Top-down maps, floor plans |
-| `GlyphFirstPersonControls` | Drag looks around; WASD / arrows move | Walk-through scenes |
+| `GlyphFirstPersonControls` | Pointer-lock look; WASD move, jump, crouch | Walk-through scenes |
 
 ## Orbit controls
 
@@ -172,22 +172,34 @@ const controls = createGlyphMapControls(scene, { drag: true, wheel: true });
 
 ## First-person controls
 
-Pointer-drag looks around; WASD / arrow keys move the camera. Good for walk-through
-environments and large scenes where the mesh fills the whole grid.
+Pointer-lock mouselook, WASD / arrow planar move, Space jump, Ctrl crouch — each
+axis independently toggleable. Good for walk-through environments and large scenes.
+Click the scene to capture the pointer; Esc releases it.
 
 **Requires a perspective camera.** `GlyphFirstPersonControls` throws if attached
 to a scene with an orthographic camera. Use `<GlyphPerspectiveCamera>` explicitly
 (not `<GlyphCamera>`, which aliases orthographic).
 
+Distances are in world units — size `moveSpeed` / `eyeHeight` to your mesh's scale
+(the gallery derives them from the model bbox).
+
 ### Props
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `drag` | `boolean` | `true` | Enable pointer-drag look |
-| `keyboard` | `boolean` | `true` | Enable WASD / arrow key movement |
-| `moveSpeed` | `number` | `0.05` | World units per keypress |
-| `lookSpeed` | `number` | `0.15` | Degrees per pixel of drag |
-| `invert` | `boolean \| number` | `false` | Invert look direction |
+| `lookEnabled` | `boolean` | `true` | Pointer-lock mouselook |
+| `moveEnabled` | `boolean` | `true` | WASD / arrow planar movement |
+| `jumpEnabled` | `boolean` | `true` | Space-bar jump arc |
+| `crouchEnabled` | `boolean` | `true` | Ctrl crouch |
+| `lookSensitivity` | `number` | `0.15` | Degrees per pixel of mouse |
+| `invertY` | `boolean` | `false` | Invert vertical look |
+| `moveSpeed` | `number` | `5` | World units per second |
+| `jumpVelocity` | `number` | `7` | Initial jump velocity (units/s) |
+| `gravity` | `number` | `18` | Gravity (units/s²) |
+| `eyeHeight` | `number` | `1.7` | Standing eye height above ground |
+| `crouchHeight` | `number` | `1` | Eye height while crouching |
+| `groundZ` | `number` | `0` | World Z of the ground plane |
+| `minPitch` / `maxPitch` | `number` | `5` / `175` | Pitch clamp (degrees) |
 
 <Tabs syncKey="fw">
   <TabItem label="React">
@@ -202,7 +214,7 @@ export function FPVDemo() {
   return (
     <GlyphPerspectiveCamera>
       <GlyphScene mode="solid" cols={140} rows={42}>
-        <GlyphFirstPersonControls drag keyboard moveSpeed={0.1} />
+        <GlyphFirstPersonControls moveSpeed={3} eyeHeight={1.2} />
         <GlyphMesh polygons={floor} />
       </GlyphScene>
     </GlyphPerspectiveCamera>
@@ -217,7 +229,7 @@ export function FPVDemo() {
 <template>
   <GlyphPerspectiveCamera>
     <GlyphScene mode="solid" :cols="140" :rows="42">
-      <GlyphFirstPersonControls drag keyboard :move-speed="0.1" />
+      <GlyphFirstPersonControls :move-speed="3" :eye-height="1.2" />
       <GlyphMesh :polygons="floor" />
     </GlyphScene>
   </GlyphPerspectiveCamera>
@@ -244,9 +256,8 @@ const scene = createGlyphScene(host, { camera, mode: "solid", cols: 140, rows: 4
 scene.add(cubePolygons({ center: [0, -0.6, 0], size: 4, color: "#334455" }));
 
 const controls = createGlyphFirstPersonControls(scene, {
-  drag: true,
-  keyboard: true,
-  moveSpeed: 0.1,
+  moveSpeed: 3,
+  eyeHeight: 1.2,
 });
 ```
 

--- a/website/src/glyph-runtime.ts
+++ b/website/src/glyph-runtime.ts
@@ -33,6 +33,7 @@ import {
   createGlyphScene,
   createGlyphOrbitControls,
   createGlyphMapControls,
+  createGlyphFirstPersonControls,
   createGlyphPerspectiveCamera,
   createGlyphOrthographicCamera,
   loadMesh,
@@ -46,7 +47,7 @@ import type {
   ParseAnimationClip,
   Polygon,
 } from 'glyphcss';
-import type { GlyphSceneHandle } from 'glyphcss';
+import type { GlyphSceneHandle, GlyphFirstPersonControlsHandle, GlyphFirstPersonControlsOptions } from 'glyphcss';
 import { resolveGeometry } from '@glyphcss/core';
 
 type GeometryName = 'cuboctahedron' | 'icosahedron' | 'cube';
@@ -1232,228 +1233,90 @@ function initGlyphDemo(demoEl: HTMLElement): void {
     rebuildSceneFromGeometry();
   }
 
-  // ── FPV state ─────────────────────────────────────────────────────────────
-  let fpvOrigin: [number, number, number] = [0, 0, controlState.fpv.groundZ + controlState.fpv.eyeHeight];
-  // Scales FPV distances/speeds to the model. Meshes keep their authored scale
-  // (autoCenter is center-only), so a fixed back-off/eye-height/move-speed would
-  // break on non-unit models — spawning you inside a large one. `maxDim/2` is 1
-  // for the old 2-unit mesh (identical behavior) and grows with the model.
-  let fpvModelScale = 1;
-  let fpvVerticalVel = 0;
-  let fpvJumpOffset = 0;
-  let fpvRafId: number | null = null;
-  let fpvLastTime = 0;
-  let fpvPointerLocked = false;
-  const fpvKeysHeld = new Set<string>();
+  // ── FPV (first-person) ─────────────────────────────────────────────────────
+  // Uses the library control (createGlyphFirstPersonControls). The gallery only
+  // supplies model-relative spawn + options — meshes keep their authored scale
+  // (autoCenter is center-only), so distances/speeds scale by the model size.
+  // Mirrors voxcss (control in the library, spawn config in the website).
+  let fpvControl: GlyphFirstPersonControlsHandle | null = null;
   let fpvSavedProjection: 'perspective' | 'orthographic' | null = null;
   let fpvSavedDistance: number | null = null;
   let fpvSavedRotX: number | null = null;
   let fpvSavedZoom: number | null = null;
   const FPV_PERSPECTIVE_DISTANCE = 200;
 
-  const FPV_FORWARD_KEYS = new Set(['KeyW', 'ArrowUp']);
-  const FPV_BACK_KEYS = new Set(['KeyS', 'ArrowDown']);
-  const FPV_LEFT_KEYS = new Set(['KeyA', 'ArrowLeft']);
-  const FPV_RIGHT_KEYS = new Set(['KeyD', 'ArrowRight']);
-  const FPV_JUMP_KEYS = new Set(['Space']);
-  const FPV_CROUCH_KEYS = new Set(['ControlLeft', 'ControlRight']);
-
-  function fpvForwardDir(rotXDeg: number, rotYDeg: number): [number, number, number] {
-    const rx = (rotXDeg * Math.PI) / 180;
-    const ry = (rotYDeg * Math.PI) / 180;
-    return [
-      -Math.sin(rx) * Math.cos(ry),
-      -Math.sin(rx) * Math.sin(ry),
-      -Math.cos(rx),
-    ];
-  }
-
-  function fpvSyncTarget(): void {
-    const f = fpvForwardDir(camera.rotX, camera.rotY);
-    camera.target = [
-      fpvOrigin[0] + f[0] * 0,
-      fpvOrigin[1] + f[1] * 0,
-      fpvOrigin[2] + f[2] * 0,
-    ];
-  }
-
-  function fpvInitOriginFromCamera(): void {
-    // Derive a model-relative scale from the bbox so the spawn back-off + eye
-    // height fit the actual model (mirrors voxcss useFpvSpawn). maxDim/2 == 1
-    // for the old 2-unit mesh, so unit-scale models are unchanged.
+  // Model bbox → scale (maxDim/2; 1 for a 2-unit mesh). Used to size eye height,
+  // speeds, spawn distance and the FPV zoom to the model's authored scale.
+  function fpvModelScale(): number {
     const polys = geometry.polygons as Polygon[];
-    let minX = Infinity, minY = Infinity, minZ = Infinity;
-    let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+    let mnx = Infinity, mxx = -Infinity, mny = Infinity, mxy = -Infinity, mnz = Infinity, mxz = -Infinity;
     for (const p of polys) for (const v of p.vertices) {
-      if (v[0] < minX) minX = v[0]; if (v[0] > maxX) maxX = v[0];
-      if (v[1] < minY) minY = v[1]; if (v[1] > maxY) maxY = v[1];
-      if (v[2] < minZ) minZ = v[2]; if (v[2] > maxZ) maxZ = v[2];
+      if (v[0] < mnx) mnx = v[0]; if (v[0] > mxx) mxx = v[0];
+      if (v[1] < mny) mny = v[1]; if (v[1] > mxy) mxy = v[1];
+      if (v[2] < mnz) mnz = v[2]; if (v[2] > mxz) mxz = v[2];
     }
-    const hasBbox = isFinite(minX);
-    const cx = hasBbox ? (minX + maxX) / 2 : camera.target[0];
-    const cy = hasBbox ? (minY + maxY) / 2 : camera.target[1];
-    const maxDim = hasBbox ? Math.max(maxX - minX, maxY - minY, maxZ - minZ, 0.001) : 2;
-    fpvModelScale = maxDim / 2;
-    // eyeMode apparent size ∝ zoom (the scaled back-off cancels the model size,
-    // focal is constant). The orbit auto-fit zoom shrinks ∝ 1/scale for big
-    // models, so normalize it by the model scale → consistent FPV view at any
-    // size. (For the old 2-unit mesh fpvModelScale is 1, so this is a no-op.)
-    camera.zoom = (fpvSavedZoom ?? camera.zoom) * fpvModelScale;
-    tunables.zoom = camera.zoom;
-    fpvJumpOffset = 0;
-    fpvVerticalVel = 0;
-    camera.rotX = 90;
-    tunables.rotX = 90;
-    const back = 1.5 * fpvModelScale;
-    const f = fpvForwardDir(camera.rotX, camera.rotY);
-    fpvOrigin = [
-      cx - f[0] * back,
-      cy - f[1] * back,
-      controlState.fpv.groundZ + controlState.fpv.eyeHeight * fpvModelScale,
-    ];
-    fpvSyncTarget();
+    if (!isFinite(mnx)) return 1;
+    return Math.max(mxx - mnx, mxy - mny, mxz - mnz, 0.001) / 2;
   }
 
-  const fpvOnPointerLockChange = (): void => {
-    const locked = document.pointerLockElement === sceneHost;
-    fpvPointerLocked = locked;
-  };
-
-  const fpvOnMouseMove = (e: MouseEvent): void => {
-    if (!fpvPointerLocked || controlState.dragMode !== 'fpv') return;
-    if (!controlState.fpv.look) return;
-    const dx = e.movementX ?? 0;
-    const dy = e.movementY ?? 0;
-    if (dx === 0 && dy === 0) return;
-    const sens = controlState.fpv.lookSensitivity;
-    const dyDir = controlState.fpv.invertY ? -1 : 1;
-    // Camera is now in degrees; sensitivity is in degrees/pixel.
-    camera.rotY = camera.rotY - dx * sens;
-    let rotX = camera.rotX - dy * sens * dyDir;
-    const minDeg = controlState.fpv.minPitch;
-    const maxDeg = controlState.fpv.maxPitch;
-    if (rotX < minDeg) rotX = minDeg;
-    else if (rotX > maxDeg) rotX = maxDeg;
-    camera.rotX = rotX;
-    fpvSyncTarget();
-    doRerender();
-  };
-
-  const fpvOnKeyDown = (e: KeyboardEvent): void => {
-    if (controlState.dragMode !== 'fpv') return;
-    const code = e.code;
-    const isFpvKey = FPV_FORWARD_KEYS.has(code) || FPV_BACK_KEYS.has(code) ||
-      FPV_LEFT_KEYS.has(code) || FPV_RIGHT_KEYS.has(code) ||
-      FPV_JUMP_KEYS.has(code) || FPV_CROUCH_KEYS.has(code);
-    if (!isFpvKey) return;
-    if (!fpvPointerLocked && !controlState.fpv.move) return;
-    if (FPV_JUMP_KEYS.has(code)) {
-      if (!controlState.fpv.jump) return;
-      e.preventDefault();
-      if (!fpvKeysHeld.has(code) && fpvVerticalVel === 0 && fpvJumpOffset === 0) {
-        fpvVerticalVel = controlState.fpv.jumpVelocity * fpvModelScale;
-      }
-      fpvKeysHeld.add(code);
-      return;
-    }
-    if (FPV_CROUCH_KEYS.has(code) && !controlState.fpv.crouch) return;
-    if (!controlState.fpv.move && !FPV_CROUCH_KEYS.has(code)) return;
-    e.preventDefault();
-    fpvKeysHeld.add(code);
-  };
-
-  const fpvOnKeyUp = (e: KeyboardEvent): void => { fpvKeysHeld.delete(e.code); };
-  const fpvOnBlur = (): void => { fpvKeysHeld.clear(); };
-  const fpvOnClick = (): void => {
-    if (controlState.dragMode !== 'fpv' || fpvPointerLocked) return;
-    if (!controlState.fpv.look) return;
-    try { sceneHost.requestPointerLock(); } catch { /* ignore */ }
-  };
-
-  const FPV_DT_CLAMP = 0.05;
-
-  const fpvTick = (now: number): void => {
-    if (fpvRafId === null || controlState.dragMode !== 'fpv') return;
-    const dt = Math.min(FPV_DT_CLAMP, fpvLastTime ? (now - fpvLastTime) / 1000 : 0.0167);
-    fpvLastTime = now;
-
-    let dirty = false;
-
-    if (controlState.fpv.move) {
-      let mf = 0, mr = 0;
-      for (const code of fpvKeysHeld) {
-        if (FPV_FORWARD_KEYS.has(code)) mf += 1;
-        else if (FPV_BACK_KEYS.has(code)) mf -= 1;
-        else if (FPV_RIGHT_KEYS.has(code)) mr += 1;
-        else if (FPV_LEFT_KEYS.has(code)) mr -= 1;
-      }
-      if (mf !== 0 || mr !== 0) {
-        const r = (camera.rotY * Math.PI) / 180;
-        const fx = -Math.cos(r), fy = -Math.sin(r);
-        const rx = -Math.sin(r), ry =  Math.cos(r);
-        const len = Math.hypot(mf, mr) || 1;
-        const step = controlState.fpv.moveSpeed * fpvModelScale * dt;
-        fpvOrigin[0] += ((fx * mf + rx * mr) / len) * step;
-        fpvOrigin[1] += ((fy * mf + ry * mr) / len) * step;
-        dirty = true;
-      }
-    }
-
-    const crouched = controlState.fpv.crouch &&
-      (fpvKeysHeld.has('ControlLeft') || fpvKeysHeld.has('ControlRight'));
-    const baseHeight = (crouched ? controlState.fpv.crouchHeight : controlState.fpv.eyeHeight) * fpvModelScale;
-    if (controlState.fpv.jump && (fpvVerticalVel !== 0 || fpvJumpOffset > 0)) {
-      fpvVerticalVel -= controlState.fpv.gravity * fpvModelScale * dt;
-      fpvJumpOffset += fpvVerticalVel * dt;
-      if (fpvJumpOffset <= 0) { fpvJumpOffset = 0; fpvVerticalVel = 0; }
-    } else if (!controlState.fpv.jump) {
-      fpvJumpOffset = 0; fpvVerticalVel = 0;
-    }
-    const originZ = controlState.fpv.groundZ + baseHeight + fpvJumpOffset;
-    if (Math.abs(fpvOrigin[2] - originZ) > 1e-4) { fpvOrigin[2] = originZ; dirty = true; }
-
-    if (dirty) {
-      fpvSyncTarget();
-      doRerender();
-    }
-
-    fpvRafId = requestAnimationFrame(fpvTick);
-  };
+  function fpvScaledOptions(scale: number): GlyphFirstPersonControlsOptions {
+    const f = controlState.fpv;
+    return {
+      lookEnabled: f.look,
+      moveEnabled: f.move,
+      jumpEnabled: f.jump,
+      crouchEnabled: f.crouch,
+      lookSensitivity: f.lookSensitivity,
+      invertY: f.invertY,
+      moveSpeed: f.moveSpeed * scale,
+      jumpVelocity: f.jumpVelocity * scale,
+      gravity: f.gravity * scale,
+      eyeHeight: f.eyeHeight * scale,
+      crouchHeight: f.crouchHeight * scale,
+      groundZ: f.groundZ,
+      minPitch: f.minPitch,
+      maxPitch: f.maxPitch,
+    };
+  }
 
   function startFpv(): void {
     fpvSavedProjection = controlState.projection;
     fpvSavedDistance = tunables.distance;
     fpvSavedRotX = tunables.rotX;
     fpvSavedZoom = tunables.zoom;
+    const scale = fpvModelScale();
     controlState.projection = 'perspective';
     tunables.distance = FPV_PERSPECTIVE_DISTANCE;
-    fpvInitOriginFromCamera();
+    // eyeMode apparent size scales with zoom; the orbit auto-fit zoom shrinks
+    // ~1/scale for big models, so normalize it (consistent FPV view at any size).
+    tunables.zoom = (fpvSavedZoom ?? tunables.zoom) * scale;
+    tunables.rotX = 90;
     stopAutoRotate();
     controlState.rotYLocked = true;
-    document.addEventListener('pointerlockchange', fpvOnPointerLockChange);
-    document.addEventListener('mousemove', fpvOnMouseMove);
-    window.addEventListener('keydown', fpvOnKeyDown);
-    window.addEventListener('keyup', fpvOnKeyUp);
-    window.addEventListener('blur', fpvOnBlur);
-    sceneHost.addEventListener('click', fpvOnClick);
-    sceneHost.style.cursor = controlState.fpv.look ? 'crosshair' : '';
+    // Rebuild so the scene has a perspective (eyeMode) camera the control needs.
     rebuildSceneFromGeometry();
-    fpvLastTime = 0;
-    fpvRafId = requestAnimationFrame(fpvTick);
+    // Spawn one+ model-span behind the model center along the current look dir.
+    const polys = geometry.polygons as Polygon[];
+    let cx = camera.target[0], cy = camera.target[1];
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    for (const p of polys) for (const v of p.vertices) {
+      if (v[0] < minX) minX = v[0]; if (v[0] > maxX) maxX = v[0];
+      if (v[1] < minY) minY = v[1]; if (v[1] > maxY) maxY = v[1];
+    }
+    if (isFinite(minX)) { cx = (minX + maxX) / 2; cy = (minY + maxY) / 2; }
+    const back = 1.5 * scale;
+    const r = (camera.rotY * Math.PI) / 180;
+    // forward at rotX=90 is (-cos rotY, -sin rotY, 0); spawn the opposite way.
+    const spawnX = cx + Math.cos(r) * back;
+    const spawnY = cy + Math.sin(r) * back;
+    fpvControl = createGlyphFirstPersonControls(scene, fpvScaledOptions(scale));
+    fpvControl.setOrigin([spawnX, spawnY, controlState.fpv.groundZ + controlState.fpv.eyeHeight * scale]);
   }
 
   function stopFpv(): void {
-    if (fpvRafId !== null) { cancelAnimationFrame(fpvRafId); fpvRafId = null; }
-    if (fpvPointerLocked) { try { document.exitPointerLock(); } catch { /* ignore */ } }
-    fpvPointerLocked = false;
-    fpvKeysHeld.clear();
-    document.removeEventListener('pointerlockchange', fpvOnPointerLockChange);
-    document.removeEventListener('mousemove', fpvOnMouseMove);
-    window.removeEventListener('keydown', fpvOnKeyDown);
-    window.removeEventListener('keyup', fpvOnKeyUp);
-    window.removeEventListener('blur', fpvOnBlur);
-    sceneHost.removeEventListener('click', fpvOnClick);
-    sceneHost.style.cursor = '';
+    fpvControl?.destroy();
+    fpvControl = null;
+    controlState.rotYLocked = false;
     if (fpvSavedProjection !== null) controlState.projection = fpvSavedProjection;
     if (fpvSavedDistance !== null) tunables.distance = fpvSavedDistance;
     if (fpvSavedRotX !== null) tunables.rotX = fpvSavedRotX;
@@ -1462,7 +1325,6 @@ function initGlyphDemo(demoEl: HTMLElement): void {
     fpvSavedDistance = null;
     fpvSavedRotX = null;
     fpvSavedZoom = null;
-    camera.target = [fpvOrigin[0], fpvOrigin[1], controlState.fpv.groundZ];
     rebuildSceneFromGeometry();
   }
 
@@ -1480,16 +1342,11 @@ function initGlyphDemo(demoEl: HTMLElement): void {
 
   function setFpvOptions(partial: Partial<FpvOptions>): void {
     Object.assign(controlState.fpv, partial);
-    if (controlState.dragMode === 'fpv') {
-      if ('eyeHeight' in partial || 'groundZ' in partial) {
-        fpvOrigin[2] = controlState.fpv.groundZ + controlState.fpv.eyeHeight;
-        fpvSyncTarget();
-      }
-      if ('look' in partial) {
-        sceneHost.style.cursor = controlState.fpv.look ? 'crosshair' : '';
-      }
+    if (controlState.dragMode === 'fpv' && fpvControl) {
+      fpvControl.update(fpvScaledOptions(fpvModelScale()));
     }
   }
+
 
   // ── Triangle click picking (non-FPV) ──────────────────────────────────────
   // Attach a click handler on the scene's output element

--- a/website/src/glyph-runtime.ts
+++ b/website/src/glyph-runtime.ts
@@ -1234,6 +1234,11 @@ function initGlyphDemo(demoEl: HTMLElement): void {
 
   // ── FPV state ─────────────────────────────────────────────────────────────
   let fpvOrigin: [number, number, number] = [0, 0, controlState.fpv.groundZ + controlState.fpv.eyeHeight];
+  // Scales FPV distances/speeds to the model. Meshes keep their authored scale
+  // (autoCenter is center-only), so a fixed back-off/eye-height/move-speed would
+  // break on non-unit models — spawning you inside a large one. `maxDim/2` is 1
+  // for the old 2-unit mesh (identical behavior) and grows with the model.
+  let fpvModelScale = 1;
   let fpvVerticalVel = 0;
   let fpvJumpOffset = 0;
   let fpvRafId: number | null = null;
@@ -1243,6 +1248,7 @@ function initGlyphDemo(demoEl: HTMLElement): void {
   let fpvSavedProjection: 'perspective' | 'orthographic' | null = null;
   let fpvSavedDistance: number | null = null;
   let fpvSavedRotX: number | null = null;
+  let fpvSavedZoom: number | null = null;
   const FPV_PERSPECTIVE_DISTANCE = 200;
 
   const FPV_FORWARD_KEYS = new Set(['KeyW', 'ArrowUp']);
@@ -1272,17 +1278,38 @@ function initGlyphDemo(demoEl: HTMLElement): void {
   }
 
   function fpvInitOriginFromCamera(): void {
-    const t = camera.target;
+    // Derive a model-relative scale from the bbox so the spawn back-off + eye
+    // height fit the actual model (mirrors voxcss useFpvSpawn). maxDim/2 == 1
+    // for the old 2-unit mesh, so unit-scale models are unchanged.
+    const polys = geometry.polygons as Polygon[];
+    let minX = Infinity, minY = Infinity, minZ = Infinity;
+    let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+    for (const p of polys) for (const v of p.vertices) {
+      if (v[0] < minX) minX = v[0]; if (v[0] > maxX) maxX = v[0];
+      if (v[1] < minY) minY = v[1]; if (v[1] > maxY) maxY = v[1];
+      if (v[2] < minZ) minZ = v[2]; if (v[2] > maxZ) maxZ = v[2];
+    }
+    const hasBbox = isFinite(minX);
+    const cx = hasBbox ? (minX + maxX) / 2 : camera.target[0];
+    const cy = hasBbox ? (minY + maxY) / 2 : camera.target[1];
+    const maxDim = hasBbox ? Math.max(maxX - minX, maxY - minY, maxZ - minZ, 0.001) : 2;
+    fpvModelScale = maxDim / 2;
+    // eyeMode apparent size ∝ zoom (the scaled back-off cancels the model size,
+    // focal is constant). The orbit auto-fit zoom shrinks ∝ 1/scale for big
+    // models, so normalize it by the model scale → consistent FPV view at any
+    // size. (For the old 2-unit mesh fpvModelScale is 1, so this is a no-op.)
+    camera.zoom = (fpvSavedZoom ?? camera.zoom) * fpvModelScale;
+    tunables.zoom = camera.zoom;
     fpvJumpOffset = 0;
     fpvVerticalVel = 0;
     camera.rotX = 90;
     tunables.rotX = 90;
-    const initBackOffset = 3;
+    const back = 1.5 * fpvModelScale;
     const f = fpvForwardDir(camera.rotX, camera.rotY);
     fpvOrigin = [
-      t[0] - f[0] * initBackOffset,
-      t[1] - f[1] * initBackOffset,
-      controlState.fpv.groundZ + controlState.fpv.eyeHeight,
+      cx - f[0] * back,
+      cy - f[1] * back,
+      controlState.fpv.groundZ + controlState.fpv.eyeHeight * fpvModelScale,
     ];
     fpvSyncTarget();
   }
@@ -1324,7 +1351,7 @@ function initGlyphDemo(demoEl: HTMLElement): void {
       if (!controlState.fpv.jump) return;
       e.preventDefault();
       if (!fpvKeysHeld.has(code) && fpvVerticalVel === 0 && fpvJumpOffset === 0) {
-        fpvVerticalVel = controlState.fpv.jumpVelocity;
+        fpvVerticalVel = controlState.fpv.jumpVelocity * fpvModelScale;
       }
       fpvKeysHeld.add(code);
       return;
@@ -1365,7 +1392,7 @@ function initGlyphDemo(demoEl: HTMLElement): void {
         const fx = -Math.cos(r), fy = -Math.sin(r);
         const rx = -Math.sin(r), ry =  Math.cos(r);
         const len = Math.hypot(mf, mr) || 1;
-        const step = controlState.fpv.moveSpeed * dt;
+        const step = controlState.fpv.moveSpeed * fpvModelScale * dt;
         fpvOrigin[0] += ((fx * mf + rx * mr) / len) * step;
         fpvOrigin[1] += ((fy * mf + ry * mr) / len) * step;
         dirty = true;
@@ -1374,9 +1401,9 @@ function initGlyphDemo(demoEl: HTMLElement): void {
 
     const crouched = controlState.fpv.crouch &&
       (fpvKeysHeld.has('ControlLeft') || fpvKeysHeld.has('ControlRight'));
-    const baseHeight = crouched ? controlState.fpv.crouchHeight : controlState.fpv.eyeHeight;
+    const baseHeight = (crouched ? controlState.fpv.crouchHeight : controlState.fpv.eyeHeight) * fpvModelScale;
     if (controlState.fpv.jump && (fpvVerticalVel !== 0 || fpvJumpOffset > 0)) {
-      fpvVerticalVel -= controlState.fpv.gravity * dt;
+      fpvVerticalVel -= controlState.fpv.gravity * fpvModelScale * dt;
       fpvJumpOffset += fpvVerticalVel * dt;
       if (fpvJumpOffset <= 0) { fpvJumpOffset = 0; fpvVerticalVel = 0; }
     } else if (!controlState.fpv.jump) {
@@ -1397,6 +1424,7 @@ function initGlyphDemo(demoEl: HTMLElement): void {
     fpvSavedProjection = controlState.projection;
     fpvSavedDistance = tunables.distance;
     fpvSavedRotX = tunables.rotX;
+    fpvSavedZoom = tunables.zoom;
     controlState.projection = 'perspective';
     tunables.distance = FPV_PERSPECTIVE_DISTANCE;
     fpvInitOriginFromCamera();
@@ -1429,9 +1457,11 @@ function initGlyphDemo(demoEl: HTMLElement): void {
     if (fpvSavedProjection !== null) controlState.projection = fpvSavedProjection;
     if (fpvSavedDistance !== null) tunables.distance = fpvSavedDistance;
     if (fpvSavedRotX !== null) tunables.rotX = fpvSavedRotX;
+    if (fpvSavedZoom !== null) tunables.zoom = fpvSavedZoom;
     fpvSavedProjection = null;
     fpvSavedDistance = null;
     fpvSavedRotX = null;
+    fpvSavedZoom = null;
     camera.target = [fpvOrigin[0], fpvOrigin[1], controlState.fpv.groundZ];
     rebuildSceneFromGeometry();
   }


### PR DESCRIPTION
Brings the **controls** to parity with polycss/voxcss — same surface, no glyphcss-only drift.

## FPV — full parity
- `createGlyphFirstPersonControls`: faithful voxcss port — pointer-lock look, WASD, Space jump (gravity arc), Ctrl crouch; full option surface + handle (`lock/unlock/isLocked/getOrigin/setOrigin/…`). glyphcss delta: eyeMode camera sync (no CSS-perspective host) — ASCII adaptation, not drift.
- **React + Vue `GlyphFirstPersonControls`** expose the full option set.
- **`<glyph-first-person-controls>` custom element** added + registered + tested.
- **Gallery consumes the library control** (dropped its ~250-line bespoke FPV) with model-relative spawn (mirrors voxcss `useFpvSpawn`).

## Controls event system — full parity
- New `api/controls/common.ts` = voxcss's event pieces (camera snapshot + `change`/`start`/`end` listener registry).
- **orbit / map / first-person** handles now expose `addEventListener` / `removeEventListener` / `hasEventListener`, emitting `change` on every camera mutation and `start`/`end` on drag + wheel-idle + pointer-lock. Types exported from the package (parity with voxcss `PolyControls*` events). (voxcss's React/Vue wrappers don't expose event props either, so the wrappers are already at parity.)

## Verified
- `pnpm test` (all packages: core 765, glyphcss 262, react/vue 163 ea.) + `pnpm build` green.
- Gallery FPV via the library control: army.vox 53×28, Dog 47×22 — framed, 0 errors.
- Orbit/map/fpv event tests added.

## Not in this PR — transform controls (genuine architectural blocker, not a skip)
voxcss's `createTransformControls` picks gizmo handles via `pointInMeshElement(handle.element, …)` — hit-testing **each gizmo's own DOM element**. polycss renders every mesh as a DOM node; **glyphcss renders everything into one `<pre>` with no per-mesh DOM**, so there is no `handle.element` to hit-test. Porting it requires building **package-level triangle raycasting** first (the gallery has `pickTriangle`, but it's not in the package). That's a prerequisite infra feature — shipping gizmos without real hit-testing would be exactly the drift this work is removing. Flagged as the next dedicated effort (build raycasting → then transform controls).
