### PR TITLE
fix(gallery): FPV survives projection toggle + line-height no longer distorts it

### DIFF
--- a/website/src/glyph-runtime.ts
+++ b/website/src/glyph-runtime.ts
@@ -1149,6 +1149,9 @@ function initGlyphDemo(demoEl: HTMLElement): void {
 
     // Re-create controls with new camera/options
     buildControls();
+    // FPV uses the library control (not buildControls); it captured the prior
+    // camera, so rebind it to the freshly-built one or WASD/look go dead.
+    rebindFpvControl();
 
     applyMesh();
     rebuildFloor();
@@ -1277,6 +1280,16 @@ function initGlyphDemo(demoEl: HTMLElement): void {
       minPitch: f.minPitch,
       maxPitch: f.maxPitch,
     };
+  }
+
+  // A scene rebuild replaces `camera`; the FPV control captured the old one,
+  // so re-create it against the new camera, preserving the eye position.
+  function rebindFpvControl(): void {
+    if (controlState.dragMode !== 'fpv' || !fpvControl) return;
+    const origin = fpvControl.getOrigin();
+    fpvControl.destroy();
+    fpvControl = createGlyphFirstPersonControls(scene, fpvScaledOptions(fpvModelScale()));
+    fpvControl.setOrigin(origin);
   }
 
   function startFpv(): void {
@@ -1431,9 +1444,18 @@ function initGlyphDemo(demoEl: HTMLElement): void {
       const nextLineHeight = partial.lineHeight;
       scene.output.style.lineHeight = String(nextLineHeight);
       scene.fit();
-      if (prevLineHeight > 0 && nextLineHeight > 0 && camera.zoom > 0 && !camera.eyeMode) {
+      // The col/row projection scales as `zoom · cellAspect` / `zoom`, and
+      // cellAspect tracks line-height, so the inverse-ratio zoom compensation
+      // holds framing in BOTH ortho and eyeMode (FPV) — without it, FPV's
+      // horizontal scale distorts (width changes) when line-height changes.
+      if (prevLineHeight > 0 && nextLineHeight > 0 && camera.zoom > 0) {
         camera.zoom = Math.round(camera.zoom * (prevLineHeight / nextLineHeight) * 1000) / 1000;
         tunables.zoom = camera.zoom;
+        // In FPV, the saved orbit zoom (restored on exit) must track the same
+        // ratio so leaving FPV doesn't snap to a stale zoom.
+        if (fpvSavedZoom !== null) {
+          fpvSavedZoom = Math.round(fpvSavedZoom * (prevLineHeight / nextLineHeight) * 1000) / 1000;
+        }
       }
     }
 


### PR DESCRIPTION
Two FPV bugs in the gallery (reported after v0.0.7):

## 1. Projection toggle broke FPV
The gallery's FPV uses the library control, which captures `scene.camera` on creation. Any **scene rebuild** (`setProjection`, render-mode / feature-edges change, mesh swap) replaces the camera via `rebuildSceneFromGeometry`, leaving the FPV control bound to the **old camera** → WASD / mouselook went dead.

**Fix:** `rebuildSceneFromGeometry` now calls `rebindFpvControl()` after rebuilding — re-creates the FPV control against the fresh camera, preserving the eye position. (`buildControls` already early-returns for FPV, so no conflict.)

## 2. Line-height distorted the FPV view
The line-height zoom-compensation (which holds framing as cell aspect changes) was **skipped when `camera.eyeMode`** — so in FPV the horizontal scale (∝ `zoom · cellAspect`) drifted: line-height 0.5 **halved the model width**.

**Fix:** apply the same inverse-ratio zoom compensation in eyeMode too (the col/row projection scales identically in ortho and eyeMode), and carry the ratio onto the saved orbit zoom so leaving FPV doesn't snap.

## Verified (gallery, Dog.glb in FPV)
- line-height 0.5: width holds at **47** (was 24); height row-count doubles (denser glyphs, same on-screen size). No distortion.
- After ortho→perspective toggle, WASD moves the view (47×22 → 114×37) → control alive (was dead).
- `pnpm build` green, 0 page errors.
