### PR TITLE
fix(website): synth + gallery layout in production build

### DIFF
--- a/website/src/components/GalleryWorkbench/gallery-workbench.css
+++ b/website/src/components/GalleryWorkbench/gallery-workbench.css
@@ -105,6 +105,19 @@
   --overlay-left: calc(var(--overlay-gap) + env(safe-area-inset-left, 0px));
 }
 
+/* ModelsSidebar.css also defines a bare `.models-sidebar { position: relative }`
+   (so its ::before legend anchors when used standalone). Both that rule and the
+   overlay positioning below are single-class selectors of equal specificity, so
+   the winner flips with CSS bundle order — in the prod bundle `relative` wins,
+   dropping the sidebar into normal flow and shoving the viewport (.dn-main) down
+   by the sidebar's height. Pin the overlay position at higher specificity
+   (.dn-root .models-sidebar, 0,2,0) so it wins regardless of order; the sidebar
+   only ever renders inside .dn-root, and it stays absolutely positioned across
+   every breakpoint (the mobile rules only reposition it, never un-absolute it). */
+.dn-root .models-sidebar {
+  position: absolute;
+}
+
 .models-sidebar {
   position: absolute;
   top: var(--overlay-top);

--- a/website/src/components/SynthWorkbench/synth-workbench.css
+++ b/website/src/components/SynthWorkbench/synth-workbench.css
@@ -1,8 +1,16 @@
-.synth-shell {
+/* The shell element carries both `synth-shell` and `dn-root` (the shared Dock
+   overlay class from gallery-workbench.css). Both are single-class selectors, so
+   `.dn-root`'s position/height/display/background would win or lose purely on CSS
+   bundle order — fine in dev, broken in the prod bundle (shell collapses to
+   position:relative + content height, leaving a black void below the presets).
+   Qualifying with `.dn-root` raises specificity (0,2,0 > 0,1,0) so the fixed
+   full-viewport layout wins deterministically. */
+.synth-shell.dn-root {
   position: fixed;
   inset: var(--sl-nav-height, 72px) 0 0 0;
-  /* Override .dn-root's height:100% — with position:fixed + top:72px it would make
-     the shell 100vh tall starting below the nav, pushing the footer off-screen. */
+  /* height:auto (not .dn-root's height:100%) — with position:fixed + top:72px,
+     100% would make the shell 100vh tall starting below the nav, pushing the
+     footer off-screen. inset already resolves the height from nav to viewport bottom. */
   height: auto;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Two equal-specificity CSS rules lost to `.dn-root`/overlay selectors in the prod bundle (fine in dev, broken when deployed). Raised specificity so the synth shell and the gallery models sidebar keep their intended positioning.