### PR TITLE
fix: FPV camera points wrong way when loading a Parthenon URL until you move the mouse

### DIFF
--- a/website/src/pages/examples/parthenon.astro
+++ b/website/src/pages/examples/parthenon.astro
@@ -1263,9 +1263,13 @@ const description = "The Parthenon — octastyle Doric peripteral temple built f
         applyingState = false;
         setMode(st.camera === 1 ? "fpv" : "orbit");
         if (st.camera === 1 && st.fpv) {
-          fpv.setOrigin([st.fpv.x, st.fpv.y, 1.7]);
+          // Set the look angles BEFORE setOrigin: setOrigin() syncs the camera
+          // target from the current rotX/rotY, so restoring position first would
+          // bake the default look into the target and the initial render would
+          // point the wrong way until a mouse-move re-synced it.
           camera.rotX = st.fpv.pitch;
           camera.rotY = st.fpv.yaw;
+          fpv.setOrigin([st.fpv.x, st.fpv.y, 1.7]);
           scene.rerender();
         }
       }


### PR DESCRIPTION
Loading the Parthenon example with an FPV state baked into the URL hash (e.g. `#0IBnSyixT9S_t5EGyOput2M`) rendered the camera looking in the wrong direction until you moved the mouse. Happened in both matrix and marble styles — FPV only.

**Cause:** `applyState` restored the FPV **origin before** the look angles. `fpv.setOrigin()` calls `syncTarget()`, which derives `camera.target` from the *current* `rotX/rotY` — so it baked the default look into the target, and the restored `rotX/rotY` set afterwards never re-synced the target. A mouse-move fired the mouselook handler, which re-ran `syncTarget()` and corrected it.

**Fix:** set the restored `rotX/rotY` first, then call `setOrigin()`, so the target is derived from the restored look.

Verified: loading the URL with no mouse-move, the camera target azimuth matches the restored yaw.