### PR TITLE
fix: unblock publish workflow, static export resolution, and URL payload size

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -53,6 +53,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Must precede `pnpm test`, matching ci.yml's own order. `packages/compile`
+      # spawns the real built CLI as a SUBPROCESS (labelParity.test.ts), so that
+      # child resolves `glyphcss` through node_modules on disk — vitest aliases
+      # can't reach it. On a clean CI checkout `packages/glyphcss/dist` does not
+      # exist yet, so the child dies with ERR_MODULE_NOT_FOUND. It passed locally
+      # only because a previous build had left dist/ behind.
+      - name: Build packages (needed by packages/compile's CLI-subprocess tests)
+        run: pnpm build:packages
+
       - name: Run tests
         run: pnpm test
 
@@ -60,6 +69,12 @@ jobs:
         id: bump
         run: node .github/scripts/bump-versions.mjs "${{ inputs.bump }}"
 
+      # Rebuild after the bump. Today `dist` does not embed the package version
+      # (the CDN version in the interactive export is a RUNTIME option,
+      # `cdnVersion`, not a build-time constant), so this is currently
+      # redundant with the pre-test build — kept deliberately so that if any
+      # build step ever does bake the version in, the published artifact still
+      # carries the bumped one rather than the pre-bump value.
       - name: Build packages
         run: pnpm build:packages
 

--- a/packages/effects/src/index.ts
+++ b/packages/effects/src/index.ts
@@ -141,7 +141,7 @@ export type {
 // Static effect export — bake an effect-only, static-camera scene into a
 // self-contained pen (inlined vanilla-JS evaluator, zero glyphcss at runtime).
 // Field-synth only for now; see the module doc for what generalizing needs.
-export { buildGlyphFieldSynthStaticExport, isGlyphFieldSynthStaticExportSupported } from "./staticExport";
+export { buildGlyphFieldSynthStaticExport, isGlyphFieldSynthStaticExportSupported, glyphFieldSynthStaticExportUnsupportedReason } from "./staticExport";
 export type {
   GlyphFieldSynthStaticExportEffect,
   GlyphFieldSynthStaticExportOptions,

--- a/packages/effects/src/staticExport.test.ts
+++ b/packages/effects/src/staticExport.test.ts
@@ -868,6 +868,87 @@ describe("buildGlyphFieldSynthStaticExport", () => {
   });
 
   // ---------------------------------------------------------------------
+  // `cellWidthPx`/`cellHeightPx` — real measured-metrics contract.
+  //
+  // Every other test in this file fits its `zoom` (e.g. `zoom: 150` above)
+  // against the SAME BASE_TILE-derived cell size `bake()` falls back to
+  // when these options are omitted (`projectionMetricsForGrid`'s
+  // `fallbackCellW = 50 / cellAspect`, `fallbackCellH = 50`,
+  // packages/glyphcss/src/render/rasterize.ts) — so none of them exercise
+  // what actually happens on the live `/synth` page, where `frameObject`
+  // (website/src/components/SynthWorkbench/synthKit.tsx) always fits `zoom`
+  // against the REAL measured `pre.getBoundingClientRect()` cell size, which
+  // is essentially never 50×(50/cellAspect) CSS px for a real monospace
+  // font. Reported bug: "Cube tiles" (a fullscreen, `cover`-fit plane)
+  // exported a CodePen whose baked silhouette covered only ~4.7% of the
+  // requested grid (a 35×22 window inside a 202×78 grid) — reprojecting a
+  // zoom fit against real ~8×16px cells onto `bake()`'s BASE_TILE fallback
+  // (25×50px at `cellAspect: 2`) shrinks the covered region by roughly the
+  // ratio of those cell sizes. Fixed by threading `cellWidthPx`/
+  // `cellHeightPx` through to `bake()`'s own `grid.cellWidth`/`cellHeight`.
+  describe("cellWidthPx/cellHeightPx (frameObject parity — reported bug: baked silhouette covering the wrong fraction of the grid)", () => {
+    // Mirrors `frameObject`'s own algorithm (synthKit.tsx): project at
+    // zoom 1 with the given real cell metrics, measure the bbox in CELLS,
+    // then set zoom so the SMALLER axis fills `fill` and the larger
+    // OVERSCANS (`cover`) — exactly what the flat "plane" stage uses
+    // (`fill: 1.02, cover: true`).
+    function fitZoomCover(
+      polygons: Polygon[], rotX: number, rotY: number, cols: number, rows: number,
+      cellAspect: number, cellWidthPx: number, cellHeightPx: number, fill: number,
+    ): number {
+      const camera = createGlyphOrthographicCamera({ rotX, rotY, zoom: 1 });
+      const metrics = { cellWidth: cellWidthPx, cellHeight: cellHeightPx };
+      let minc = Infinity, maxc = -Infinity, minr = Infinity, maxr = -Infinity;
+      for (const p of polygons) for (const v of p.vertices) {
+        const pr = camera.project(v, cols, rows, cellAspect, metrics);
+        if (pr[0]! < minc) minc = pr[0]!; if (pr[0]! > maxc) maxc = pr[0]!;
+        if (pr[1]! < minr) minr = pr[1]!; if (pr[1]! > maxr) maxr = pr[1]!;
+      }
+      const w = maxc - minc, h = maxr - minr;
+      const zc = (fill * cols) / w, zr = (fill * rows) / h;
+      return Math.max(zc, zr);
+    }
+
+    it("passing the real measured cell metrics reproduces full coverage for a cover-fit plane", () => {
+      const cols = 60, rows = 30, cellAspect = 2;
+      // Realistic monospace metrics (~13px font) — deliberately far from the
+      // BASE_TILE fallback (25×50 at cellAspect 2) so a wrong fallback would
+      // visibly under-cover, not coincidentally match.
+      const cellWidthPx = 8, cellHeightPx = 16;
+      const zoom = fitZoomCover(planeMesh(), 0, 0, cols, rows, cellAspect, cellWidthPx, cellHeightPx, 1.02);
+      const result = buildGlyphFieldSynthStaticExport(planeMesh(), baseOptions({
+        rotX: 0, rotY: 0, zoom, cols, rows, cellAspect, cellWidthPx, cellHeightPx,
+      }));
+      const cfgMatch = result.js.match(/var CFG=(\{.*\});\s*"use strict"/s);
+      const cfg = JSON.parse(cfgMatch![1]!) as { full: boolean; cols: number; rows: number };
+      expect(cfg.full).toBe(true);
+      expect(cfg.cols).toBe(cols);
+      expect(cfg.rows).toBe(rows);
+    });
+
+    it("regression pin: omitting cellWidthPx/cellHeightPx reprojects the SAME real-metric zoom onto the BASE_TILE fallback and covers only a small fraction of the grid", () => {
+      const cols = 60, rows = 30, cellAspect = 2;
+      const cellWidthPx = 8, cellHeightPx = 16;
+      // Same zoom as above — fit against the REAL metrics — but the exporter
+      // call below does NOT pass cellWidthPx/cellHeightPx, reproducing the
+      // pre-fix code path exactly.
+      const zoom = fitZoomCover(planeMesh(), 0, 0, cols, rows, cellAspect, cellWidthPx, cellHeightPx, 1.02);
+      const result = buildGlyphFieldSynthStaticExport(planeMesh(), baseOptions({
+        rotX: 0, rotY: 0, zoom, cols, rows, cellAspect,
+      }));
+      const cfgMatch = result.js.match(/var CFG=(\{.*\});\s*"use strict"/s);
+      const cfg = JSON.parse(cfgMatch![1]!) as { full: boolean; cols: number; rows: number };
+      // Not full — the baked silhouette is cropped to a small covered window,
+      // not the requested cols×rows grid (the reported defect).
+      expect(cfg.full).toBe(false);
+      const html = runBakedFrame(result.js, 0);
+      const cells = parseHtmlGrid(html, cols, rows);
+      const coveredFraction = cells.filter((c) => c.glyph !== " ").length / cells.length;
+      expect(coveredFraction).toBeLessThan(0.3);
+    });
+  });
+
+  // ---------------------------------------------------------------------
   // Parity (Acceptance 6, strong form): the baked runtime's grid output
   // must match the live `fieldSynth.program.evaluate()` render, cell for
   // cell, at matching time values. Each case below targets exactly what

--- a/packages/effects/src/staticExport.ts
+++ b/packages/effects/src/staticExport.ts
@@ -114,6 +114,27 @@ export interface GlyphFieldSynthStaticExportOptions {
   perspectivePx?: number;
   fontSizePx?: number;
   lineHeightPx?: number;
+  /**
+   * Measured live cell size in CSS px (`GridSize.cellWidth`/`cellHeight` —
+   * `packages/core/src/types.ts`), the SAME quantity `frameObject` (website's
+   * synthKit.tsx) measures via `pre.getBoundingClientRect()` to fit `zoom`.
+   * `zoom` is CSS px per world unit; the projection converts that to CELLS by
+   * dividing by the cell's own CSS px size, and `bake()`'s headless
+   * rasterizer has no DOM layout of its own to measure that from. Omitting
+   * these falls back to the internal BASE_TILE-derived cell size (50 /
+   * `cellAspect` × 50), which is almost never the caller's REAL font-driven
+   * cell size — passing a `zoom` fit against real layout without also
+   * passing the metrics it was fit against reprojects the SAME zoom onto a
+   * differently-sized virtual cell, producing a silhouette that covers the
+   * wrong fraction of `cols`×`rows` (measured: a live 202×78 grid's `zoom`
+   * baked down to a 35×22 covered region without these — same class of
+   * hazard `frameObject`'s own doc warns about, one level deeper). Only
+   * `fontSizePx`/`lineHeightPx` above (CSS text styling for the exported
+   * pen's own `<pre>`) were previously threaded through; neither reaches the
+   * projection.
+   */
+  cellWidthPx?: number;
+  cellHeightPx?: number;
   directionalLight?: GlyphDirectionalLight;
   ambientLight?: GlyphAmbientLight;
   title?: string;
@@ -250,7 +271,13 @@ function bake(
   let retained: RetainedGlyphEffectOutput | null = null;
   const ctx = buildRasterizeContext({
     camera,
-    grid: { cols: options.cols, rows: options.rows, cellAspect: options.cellAspect ?? 2 },
+    grid: {
+      cols: options.cols,
+      rows: options.rows,
+      cellAspect: options.cellAspect ?? 2,
+      ...(options.cellWidthPx !== undefined ? { cellWidth: options.cellWidthPx } : {}),
+      ...(options.cellHeightPx !== undefined ? { cellHeight: options.cellHeightPx } : {}),
+    },
     polygons,
     mode,
     directionalLight: options.directionalLight ?? { direction: [0.5, 0.7, 0.5], intensity: 1 },
@@ -1128,13 +1155,30 @@ function assertStaticExportSupported(params: GlyphEffectParamsOf<typeof fieldSyn
  * is the reference caller.
  */
 export function isGlyphFieldSynthStaticExportSupported(params: Partial<GlyphEffectParamsOf<typeof fieldSynth>>): boolean {
+  return glyphFieldSynthStaticExportUnsupportedReason(params) === null;
+}
+
+/**
+ * Same predicate as {@link isGlyphFieldSynthStaticExportSupported}, but
+ * returns WHY a patch is rejected instead of collapsing every reject into a
+ * bare `false` — `assertStaticExportSupported`'s own thrown message names the
+ * exact reason (`render: "carve"/"xray"`, `space: "object"`, an active
+ * `linearZ` voice, a nonzero `originW`, or `colorStackOn: true`), and a UI
+ * surfacing a generic hand-written explanation next to it can drift out of
+ * sync with what actually fired — the same class of bug
+ * `GLYPH_FIELD_SYNTH_VALIDATION_RULES` exists to prevent for
+ * `validateParams`'s own throw sites (see AGENTS.md). Returns `null` when
+ * `params` is supported. The website's `/synth` page's "Open in CodePen"
+ * button tooltip is the reference caller.
+ */
+export function glyphFieldSynthStaticExportUnsupportedReason(params: Partial<GlyphEffectParamsOf<typeof fieldSynth>>): string | null {
   const merged = { ...defaultGlyphEffectParams(fieldSynth), ...params, time: 0 } as GlyphEffectParamsOf<typeof fieldSynth>;
   try {
     fieldSynth.program.validateParams?.(merged);
     assertStaticExportSupported(merged);
-    return true;
-  } catch {
-    return false;
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
   }
 }
 

--- a/website/src/components/GalleryWorkbench/gallery-workbench.css
+++ b/website/src/components/GalleryWorkbench/gallery-workbench.css
@@ -445,8 +445,10 @@
   gap: 2px;
 }
 .gw-code-panel__tab {
-  background: none;
-  border: 1px solid rgba(255, 232, 184, 0.15);
+  background-color: transparent;
+  border-block: 0;
+  border-inline: 1px solid rgba(255, 232, 184, 0.15);
+  --gx-bracket: rgba(255, 232, 184, 0.15);
   color: rgba(255, 232, 184, 0.6);
   padding: 3px 10px;
   font: 11px/1 inherit;
@@ -458,11 +460,13 @@
 .gw-code-panel__tab:hover {
   color: rgba(255, 232, 184, 0.95);
   border-color: rgba(56, 189, 248, 0.5);
+  --gx-bracket: rgba(56, 189, 248, 0.5);
 }
 .gw-code-panel__tab.is-active {
   color: #03050a;
-  background: rgba(56, 189, 248, 0.85);
+  background-color: rgba(56, 189, 248, 0.85);
   border-color: rgba(56, 189, 248, 0.85);
+  --gx-bracket: rgba(56, 189, 248, 0.85);
 }
 .gw-code-panel__actions {
   margin-left: auto;
@@ -472,8 +476,10 @@
 }
 .gw-code-panel__action {
   white-space: nowrap;
-  background: none;
-  border: 1px solid rgba(255, 232, 184, 0.15);
+  background-color: transparent;
+  border-block: 0;
+  border-inline: 1px solid rgba(255, 232, 184, 0.15);
+  --gx-bracket: rgba(255, 232, 184, 0.15);
   color: rgba(255, 232, 184, 0.7);
   padding: 3px 8px;
   font: 11px/1 inherit;
@@ -483,6 +489,7 @@
 .gw-code-panel__action:hover {
   color: rgba(255, 232, 184, 0.98);
   border-color: rgba(56, 189, 248, 0.5);
+  --gx-bracket: rgba(56, 189, 248, 0.5);
 }
 .gw-code-panel__code {
   flex: 1 1 auto;
@@ -520,6 +527,78 @@
 
 .dark-scrollbar::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 232, 184, 0.32);
+}
+
+/* ── ASCII bracket buttons ────────────────────────────────────────────────
+   Site-wide button restyle: a full rectangle reads as a UI "box"; the rest of
+   the site's controls read as bracket glyphs instead (sliders `[▮▮▮▮]`,
+   checkboxes bare `[x]`/`[ ]`). This makes buttons match — full left/right
+   border, a short tick at each of the four corners, no continuous top/bottom
+   rule — via ONE shared treatment instead of hand-editing every button's own
+   border declaration.
+
+   Each target selector below still edits its OWN `border`/`background` rule
+   in place (shorthand `border: 1px solid X` → `border-inline: 1px solid X`,
+   `background: X` → `background-color: X`) rather than relying on this rule
+   to override them — `background: X` implicitly resets `background-image` to
+   `none`, and with equal-specificity single-class selectors split across
+   three separately bundled stylesheets, whichever rule's chunk loads last
+   would silently win (the exact hazard `.synth-code-panel.gw-code-panel`'s
+   own doc comment describes). Converting the shorthand to `background-color`
+   at each site means `background-image` is set in exactly one place — this
+   rule — so there is nothing left for load order to fight over. Each site
+   also sets `--gx-bracket` (the tick/border color) itself, including in its
+   own `:hover`/`:disabled`/`.is-active` states, so the corner ticks always
+   track whatever color that state already draws its border in.
+
+   Excluded, deliberately: `.gx-toggle-btn` (segmented — adjacent buttons
+   share an edge and already use a box-shadow ring for "active" specifically
+   because a border-color change there paints only 3 sides; per-segment
+   corner ticks would fight the same shared-edge problem) and anything that
+   already renders literal `[ ]` text (`.dn-copy-scene`, the Models sidebar's
+   `.control-btn` via `ModelsSidebar.css`, the `[x]`/`[ ]` checkbox glyphs) —
+   those already read as brackets and a drawn border on top would double up.
+   Small color-swatch buttons (`.dn-swatch`, `.voice-color`, `.wa-texgrid__sw`)
+   are excluded too: the whole square IS the swatch, and ticks would just draw
+   over the color/texture preview. */
+:is(
+  .gw-code-panel__tab,
+  .gw-code-panel__action,
+  .dn-mobile-tabs__button,
+  .voice-add,
+  .layer-group-add,
+  .voice-remove,
+  .synth-tile,
+  .dock-ramp-density-item,
+  .wa-imgbtn,
+  .wa-seg button,
+  .wa-tile
+) {
+  background-repeat: no-repeat;
+  background-origin: border-box;
+  background-image:
+    linear-gradient(var(--gx-bracket, rgba(255, 232, 184, 0.22)), var(--gx-bracket, rgba(255, 232, 184, 0.22))),
+    linear-gradient(var(--gx-bracket, rgba(255, 232, 184, 0.22)), var(--gx-bracket, rgba(255, 232, 184, 0.22))),
+    linear-gradient(var(--gx-bracket, rgba(255, 232, 184, 0.22)), var(--gx-bracket, rgba(255, 232, 184, 0.22))),
+    linear-gradient(var(--gx-bracket, rgba(255, 232, 184, 0.22)), var(--gx-bracket, rgba(255, 232, 184, 0.22)));
+  background-size: 4px 1px;
+  background-position: left top, right top, left bottom, right bottom;
+}
+:is(
+  .gw-code-panel__tab,
+  .gw-code-panel__action,
+  .dn-mobile-tabs__button,
+  .voice-add,
+  .layer-group-add,
+  .voice-remove,
+  .synth-tile,
+  .dock-ramp-density-item,
+  .wa-imgbtn,
+  .wa-seg button,
+  .wa-tile
+):focus-visible {
+  outline: 1px solid rgba(56, 189, 248, 0.75);
+  outline-offset: 2px;
 }
 
 .control-btn {
@@ -1502,9 +1581,11 @@
     min-width: 0;
     min-height: 44px;
     padding: 0 6px;
-    border: 1px solid rgba(255, 232, 184, 0.22);
+    border-block: 0;
+    border-inline: 1px solid rgba(255, 232, 184, 0.22);
+    --gx-bracket: rgba(255, 232, 184, 0.22);
     border-radius: 0;
-    background: rgba(15, 17, 21, 0.92);
+    background-color: rgba(15, 17, 21, 0.92);
     color: rgba(255, 232, 184, 0.9);
     font: 600 12px/1 ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
     letter-spacing: 0.01em;
@@ -1518,10 +1599,12 @@
   .dn-mobile-tabs__button.is-active {
     border-color: rgba(56, 189, 248, 0.6);
     color: #ecfeff;
+    --gx-bracket: rgba(56, 189, 248, 0.6);
   }
   .dn-mobile-tabs__button--random {
     border-color: rgba(74, 222, 128, 0.5);
     color: #dcfce7;
+    --gx-bracket: rgba(74, 222, 128, 0.5);
   }
 }
 
@@ -1579,6 +1662,7 @@
 .gw-code-panel__action--codepen {
   color: #b7f7c0;
   border-color: rgba(120, 220, 150, 0.4);
+  --gx-bracket: rgba(120, 220, 150, 0.4);
 }
 .gw-code-panel__action--codepen:disabled { opacity: 0.5; cursor: default; }
 

--- a/website/src/components/GalleryWorkbench/hooks/useEffectRouteSync.test.ts
+++ b/website/src/components/GalleryWorkbench/hooks/useEffectRouteSync.test.ts
@@ -1,11 +1,27 @@
+// @vitest-environment happy-dom
+//
+// happy-dom (rather than the file-default `node` environment) is needed for
+// the legacy-link regression block below, which exercises the REAL
+// entry-point functions (`routeInitialEffectState`/`setRouteEffectState`)
+// through an actual `window.location`. Every other test in this file is a
+// pure `effectCodec` call with no `window` dependency, so the environment
+// switch doesn't change their behavior.
 import { describe, expect, it } from "vitest";
-import { encodeEffectParamsPacked, decodeEffectParamsPacked } from "../../../lib/urlState";
-import { effectCodec } from "./useEffectRouteSync";
+import {
+  createUrlCodec,
+  decodeEffectParamsPacked,
+  encodeEffectParamsPacked,
+  encodeEffectParamsPackedLegacy,
+  readUrlParam,
+  writeUrlParam,
+  type UrlField,
+} from "../../../lib/urlState";
+import { effectCodec, routeInitialEffectState } from "./useEffectRouteSync";
 import { GALLERY_EFFECT_CATALOG, galleryEffectDefaultParams } from "../effects";
 
 describe("gallery effect route codec", () => {
   it("omits the field when there is no active effect", () => {
-    expect(effectCodec.encode({ effectId: "", effectVersion: 0, blend: "replace", paused: false, timeScale: 1, params: "" })).toBe("p1");
+    expect(effectCodec.encode({ effectId: "", effectVersion: 0, blend: "replace", paused: false, timeScale: 1, params: "" })).toBe("p2");
   });
 
   it("round-trips a real stock effect + its parameter overrides", () => {
@@ -55,5 +71,109 @@ describe("gallery effect route codec", () => {
     }
     expect(effectCodec.decode("not-valid")).toEqual({});
     expect(effectCodec.decode("p9futureversion")).toEqual({});
+  });
+});
+
+// ── Compact codec rewrite: EFFECT_SCHEMA_VERSION 1 -> 2 (website/src/lib/
+//    urlState.ts's run/list token grammar, same shared change as /synth's
+//    v4 -> v5 and /wordart's v1 -> v2) ─────────────────────────────────────
+// Every other field is unchanged; only the nested `params` field's wire
+// format changed, so a "1"-tagged `?fx=` link's `params` must decode
+// through the LEGACY pair (`decodeEffectParamsPackedLegacy`) even though
+// its outer field list is identical — see `useEffectRouteSync.ts`'s
+// `decodeEffectState`'s `raw[1] === "1"` dispatch.
+describe("gallery effect route codec — v1 legacy decode (compact codec rewrite)", () => {
+  const GALLERY_PARAM = "fx";
+
+  function overridesFor(effectId: string) {
+    const definition = GALLERY_EFFECT_CATALOG.find((d) => d.id === effectId) ?? GALLERY_EFFECT_CATALOG[0]!;
+    const defaults = galleryEffectDefaultParams(definition);
+    const overrideEntries = Object.entries(defaults).filter(([k]) => k !== "time").slice(0, 3);
+    const overrides = Object.fromEntries(overrideEntries.map(([k, v]) => {
+      const spec = definition.parameterSchema[k]!;
+      if (spec.kind === "number") return [k, (v as number) + 1];
+      if (spec.kind === "boolean") return [k, !v];
+      if (spec.kind === "string" && "values" in spec && spec.values) {
+        const alt = spec.values.find((candidate) => candidate !== v) ?? (v as string);
+        return [k, alt];
+      }
+      return [k, `${v}-changed`];
+    }));
+    return { definition, defaults, overrides };
+  }
+
+  it("a genuinely v1-tagged link decodes identically to the equivalent v2 link", () => {
+    const { definition, defaults, overrides } = overridesFor("matrix-rain");
+    const legacyFields = effectCodec.fields as readonly UrlField<Record<string, unknown>>[];
+    const legacyCodec = createUrlCodec<Record<string, unknown>>("1", legacyFields);
+    const legacyParams = encodeEffectParamsPackedLegacy(definition.parameterSchema, defaults, overrides);
+    const legacyPacked = legacyCodec.encode({
+      effectId: definition.id, effectVersion: definition.version, blend: "over", paused: true, timeScale: 2.25, params: legacyParams,
+    });
+    expect(legacyPacked[1]).toBe("1");
+
+    const currentParams = encodeEffectParamsPacked(definition.parameterSchema, defaults, overrides);
+    const currentPacked = effectCodec.encode({
+      effectId: definition.id, effectVersion: definition.version, blend: "over", paused: true, timeScale: 2.25, params: currentParams,
+    });
+
+    writeUrlParam(GALLERY_PARAM, legacyPacked);
+    const decodedLegacy = routeInitialEffectState();
+    writeUrlParam(GALLERY_PARAM, currentPacked);
+    const decodedCurrent = routeInitialEffectState();
+    expect(decodedLegacy).toEqual(decodedCurrent);
+  });
+
+  // Captured from THIS repo's code BEFORE the v2 compact-codec change landed
+  // (a real `effectCodec.encode(...)` output on the then-current v1 codec,
+  // built the same way `useEffectRouteSync.test.ts`'s own round-trip test
+  // above builds one, not hand-typed) — the strongest available proof that
+  // an already-shared /gallery `?fx=` link keeps decoding to exactly the
+  // state it always did.
+  const REAL_V1_LINK = "p1i0v11b1p1s3hd0xj.1c.HOLA-changed2130";
+
+  it("decodes the real captured v1 link to exactly its pre-change state", () => {
+    expect(REAL_V1_LINK[1]).toBe("1");
+    writeUrlParam(GALLERY_PARAM, REAL_V1_LINK);
+    const decoded = routeInitialEffectState();
+    expect(decoded.effectId).toBe("matrix-rain");
+    expect(decoded.blend).toBe("over");
+    expect(decoded.paused).toBe(true);
+    expect(decoded.timeScale).toBeCloseTo(2.25, 5);
+    // `routeInitialEffectState` returns the FULL sanitized param object
+    // (overrides merged over schema defaults, not the raw override diff),
+    // so only the 3 actually-overridden keys are asserted here.
+    expect(decoded.params.glyphs).toBe("HOLA-changed");
+    expect(decoded.params.direction).toBe("up");
+    expect(decoded.params.space).toBe("auto");
+  });
+
+  it("shows the real win on a richer applied effect (field-synth, a shipped preset's full override set)", async () => {
+    // matrix-rain's small schema (above) is a worst case for these levers —
+    // field-synth's 208-key schema and its typically-repeated per-voice
+    // values is the realistic case they're aimed at (a user picking a
+    // richer effect on /gallery, not just a small stock effect).
+    const { GlyphCssGraphicsMengerPreset, GlyphFieldSynthEffect: fieldSynthEffect, defaultGlyphEffectParams: defaultParams } = await import("@glyphcss/effects");
+    const defaults = defaultParams(fieldSynthEffect) as Record<string, unknown>;
+    const overrides = GlyphCssGraphicsMengerPreset.params as Record<string, unknown>;
+    const legacyEffectParams = encodeEffectParamsPackedLegacy(fieldSynthEffect.parameterSchema, defaults, overrides);
+    const newEffectParams = encodeEffectParamsPacked(fieldSynthEffect.parameterSchema, defaults, overrides);
+    const legacyFields = effectCodec.fields as readonly UrlField<Record<string, unknown>>[];
+    const legacyCodec = createUrlCodec<Record<string, unknown>>("1", legacyFields);
+    const legacyPacked = legacyCodec.encode({ effectId: fieldSynthEffect.id, effectVersion: fieldSynthEffect.version, blend: "over", paused: false, timeScale: 1, params: legacyEffectParams });
+    const newPacked = effectCodec.encode({ effectId: fieldSynthEffect.id, effectVersion: fieldSynthEffect.version, blend: "over", paused: false, timeScale: 1, params: newEffectParams });
+    expect(newPacked.length).toBeLessThan(legacyPacked.length);
+    // eslint-disable-next-line no-console
+    console.log(`gallery ?fx= (field-synth, Menger cssGraphics overrides): v1 ${legacyPacked.length} chars -> v2 ${newPacked.length} chars`);
+  });
+
+  it("re-encodes the same state at least as short as the captured v1 length", () => {
+    const { definition, defaults, overrides } = overridesFor("matrix-rain");
+    const params = encodeEffectParamsPacked(definition.parameterSchema, defaults, overrides);
+    const packed = effectCodec.encode({ effectId: definition.id, effectVersion: definition.version, blend: "over", paused: true, timeScale: 2.25, params });
+    expect(packed[1]).toBe("2");
+    expect(packed.length).toBeLessThanOrEqual(REAL_V1_LINK.length);
+    // eslint-disable-next-line no-console
+    console.log(`gallery fx (matrix-rain, 3 overrides): v1 ${REAL_V1_LINK.length} chars -> v2 ${packed.length} chars`);
   });
 });

--- a/website/src/components/GalleryWorkbench/hooks/useEffectRouteSync.ts
+++ b/website/src/components/GalleryWorkbench/hooks/useEffectRouteSync.ts
@@ -3,6 +3,7 @@ import type { GlyphEffectId } from "@glyphcss/effects";
 import {
   createUrlCodec,
   decodeEffectParamsPacked,
+  decodeEffectParamsPackedLegacy,
   encodeEffectParamsPacked,
   readUrlParam,
   writeUrlParam,
@@ -18,7 +19,13 @@ import {
 import type { GalleryEffectParamValue, GalleryEffectState } from "../types";
 
 const EFFECT_PARAM = "fx";
-const EFFECT_SCHEMA_VERSION = "1";
+// Bumped 1 -> 2 for the shared codec's compact-index/run/list rewrite of
+// `encodeEffectParamsPacked`/`decodeEffectParamsPacked` (website/src/lib/
+// urlState.ts) — the outer field list here is unchanged; only the nested
+// `params` field's wire format changed, so a "1"-tagged link's `params` must
+// decode through the LEGACY pair (`decodeEffectParamsPackedLegacy`) — see
+// `decodeEffectState` below.
+const EFFECT_SCHEMA_VERSION = "2";
 const EFFECT_ID_VALUES = GALLERY_EFFECT_CATALOG.map((d) => d.id);
 
 // Shape carried in the packed `fx` param. `params` is pre-packed against the
@@ -54,6 +61,12 @@ const effectFields: readonly UrlField<EffectRouteState>[] = [
 ];
 
 export const effectCodec = createUrlCodec<EffectRouteState>(EFFECT_SCHEMA_VERSION, effectFields);
+const effectCodecLegacyV1 = createUrlCodec<EffectRouteState>("1", effectFields);
+
+function decodeEffectOuter(raw: string | null): Partial<EffectRouteState> {
+  if (raw && raw[1] === "1") return effectCodecLegacyV1.decode(raw);
+  return effectCodec.decode(raw);
+}
 
 function serializeEffectState(state: GalleryEffectState): string | null {
   if (!state.effectId) return null;
@@ -73,13 +86,14 @@ function serializeEffectState(state: GalleryEffectState): string | null {
 }
 
 function decodeEffectState(raw: string | null): GalleryEffectState {
-  const route = { ...EMPTY_ROUTE_STATE, ...effectCodec.decode(raw) };
+  const route = { ...EMPTY_ROUTE_STATE, ...decodeEffectOuter(raw) };
   if (!route.effectId) return DEFAULT_GALLERY_EFFECT_STATE;
   const definition = galleryEffectDefinition(route.effectId as GlyphEffectId);
   if (!definition) return DEFAULT_GALLERY_EFFECT_STATE;
   if (route.effectVersion !== definition.version) return DEFAULT_GALLERY_EFFECT_STATE;
   const timeScale = Number.isFinite(route.timeScale) ? Math.min(Math.max(route.timeScale, 0.05), 3) : 1;
-  const overrides = decodeEffectParamsPacked(definition.parameterSchema, route.params) as Record<string, GalleryEffectParamValue>;
+  const decodeParams = raw && raw[1] === "1" ? decodeEffectParamsPackedLegacy : decodeEffectParamsPacked;
+  const overrides = decodeParams(definition.parameterSchema, route.params) as Record<string, GalleryEffectParamValue>;
   return {
     effectId: definition.id,
     effectVersion: definition.version,

--- a/website/src/components/InstrumentWorkbench/instrument-workbench.css
+++ b/website/src/components/InstrumentWorkbench/instrument-workbench.css
@@ -81,14 +81,16 @@
 .voice-add {
   font: inherit; font-size: 11px; letter-spacing: 0.04em;
   padding: 3px 10px;
-  border: 1px solid rgba(56, 189, 248, 0.55);
-  background: rgba(56, 189, 248, 0.1);
+  border-block: 0;
+  border-inline: 1px solid rgba(56, 189, 248, 0.55);
+  --gx-bracket: rgba(56, 189, 248, 0.55);
+  background-color: rgba(56, 189, 248, 0.1);
   color: rgba(56, 189, 248, 0.95);
   border-radius: 0;
   cursor: pointer;
   transition: background 0.12s ease;
 }
-.voice-add:hover:not(:disabled) { background: rgba(56, 189, 248, 0.2); }
+.voice-add:hover:not(:disabled) { background-color: rgba(56, 189, 248, 0.2); }
 .voice-add:disabled { opacity: 0.35; cursor: not-allowed; }
 /* Wraps the sidebar header's global Basic/Advanced toggle + "+ Add", so both
    sit as one group on the header's right side (`.synth-voices-head`'s own
@@ -304,11 +306,14 @@
   align-self: flex-start;
   font: inherit; font-size: 10px; letter-spacing: 0.04em;
   padding: 3px 8px;
-  border: 1px solid rgba(56, 189, 248, 0.4); background: rgba(56, 189, 248, 0.08);
+  border-block: 0;
+  border-inline: 1px solid rgba(56, 189, 248, 0.4);
+  --gx-bracket: rgba(56, 189, 248, 0.4);
+  background-color: rgba(56, 189, 248, 0.08);
   color: rgba(56, 189, 248, 0.9); border-radius: 0; cursor: pointer;
   transition: background 0.12s ease;
 }
-.layer-group-add:hover:not(:disabled) { background: rgba(56, 189, 248, 0.18); }
+.layer-group-add:hover:not(:disabled) { background-color: rgba(56, 189, 248, 0.18); }
 .layer-group-add:disabled { opacity: 0.35; cursor: not-allowed; }
 
 /* Colour voice stack section (VOLUMETRIC-4.md §1) — sits below the layer
@@ -463,10 +468,17 @@
 .voice-color::-webkit-color-swatch { border: none; }
 .voice-remove {
   font: inherit; line-height: 1; font-size: 14px; width: 18px; height: 18px;
-  border: 1px solid rgba(255, 232, 184, 0.2); background: transparent;
+  border-block: 0;
+  border-inline: 1px solid rgba(255, 232, 184, 0.2);
+  --gx-bracket: rgba(255, 232, 184, 0.2);
+  background-color: transparent;
   color: rgba(255, 160, 160, 0.85); border-radius: 0; cursor: pointer; padding: 0;
 }
-.voice-remove:hover { background: rgba(255, 90, 90, 0.16); border-color: rgba(255, 120, 120, 0.5); }
+.voice-remove:hover {
+  background-color: rgba(255, 90, 90, 0.16);
+  border-color: rgba(255, 120, 120, 0.5);
+  --gx-bracket: rgba(255, 120, 120, 0.5);
+}
 .voice-row { display: flex; gap: 6px; }
 
 /* Basic/Advanced display-mode toggle (crowding fix) — same `.gx-toggle`
@@ -639,12 +651,13 @@
   gap: 6px;
 }
 .synth-export-bar .gw-code-panel__action {
-  background: #0d1018;
+  background-color: #0d1018;
 }
 .synth-export-bar .gw-code-panel__action.is-active {
   color: #03050a;
-  background: rgba(56, 189, 248, 0.85);
+  background-color: rgba(56, 189, 248, 0.85);
   border-color: rgba(56, 189, 248, 0.85);
+  --gx-bracket: rgba(56, 189, 248, 0.85);
 }
 
 /* Compound with `.gw-code-panel` (0,2,0) rather than `.synth-code-panel`
@@ -786,11 +799,18 @@
 .dock-ramp-density-item {
   display: flex; flex-direction: column; align-items: center; gap: 3px;
   flex: 0 0 auto; width: 40px; padding: 3px 2px 4px;
-  background: rgba(2, 4, 10, 0.85); border: 1px solid rgba(255, 232, 184, 0.16);
+  background-color: rgba(2, 4, 10, 0.85);
+  border-block: 0;
+  border-inline: 1px solid rgba(255, 232, 184, 0.16);
+  --gx-bracket: rgba(255, 232, 184, 0.16);
   cursor: pointer; color: inherit; font: inherit;
 }
-.dock-ramp-density-item:hover { border-color: rgba(255, 232, 184, 0.4); }
-.dock-ramp-density-item.is-active { border-color: #38bdf8; background: rgba(56, 189, 248, 0.12); }
+.dock-ramp-density-item:hover { border-color: rgba(255, 232, 184, 0.4); --gx-bracket: rgba(255, 232, 184, 0.4); }
+.dock-ramp-density-item.is-active {
+  border-color: #38bdf8;
+  background-color: rgba(56, 189, 248, 0.12);
+  --gx-bracket: #38bdf8;
+}
 .dock-ramp-density-bars {
   display: flex; align-items: flex-end; gap: 1px; width: 100%; height: 20px;
 }
@@ -824,11 +844,18 @@
 }
 .synth-tile {
   flex: 0 0 auto; width: 104px; display: flex; flex-direction: column; padding: 0;
-  border: 1px solid rgba(255, 232, 184, 0.18); background: #04060b;
+  border-block: 0;
+  border-inline: 1px solid rgba(255, 232, 184, 0.18);
+  --gx-bracket: rgba(255, 232, 184, 0.18);
+  background-color: #04060b;
   color: rgba(255, 232, 184, 0.7); cursor: pointer; overflow: hidden; font: inherit;
   transition: border-color 0.12s ease, transform 0.12s ease;
 }
-.synth-tile:hover { border-color: rgba(56, 189, 248, 0.9); transform: translateY(-2px); }
+.synth-tile:hover {
+  border-color: rgba(56, 189, 248, 0.9);
+  transform: translateY(-2px);
+  --gx-bracket: rgba(56, 189, 248, 0.9);
+}
 /* The preview is decorative — let every click (glyph or gap) fall through to the tile button. */
 .synth-tile-scene { display: block; width: 100%; aspect-ratio: 1; overflow: hidden; background: #02040a; pointer-events: none; }
 .synth-tile-scene .glyph-output { color: rgba(255, 232, 184, 0.92); }

--- a/website/src/components/InstrumentWorkbench/instrument-workbench.css
+++ b/website/src/components/InstrumentWorkbench/instrument-workbench.css
@@ -666,8 +666,11 @@
 }
 
 @media (max-width: 760px) {
-  /* The bar duplicates the mobile tab bar's "Export" tab — hide it and rely
-     on that tab (same drawer, opened via `mobilePanel === "export"`). */
+  /* "Open in CodePen" and "Export" duplicate the mobile tab bar's "Export"
+     tab, so hide the whole bar and rely on that tab (same drawer, opened via
+     `mobilePanel === "export"`). "Copy ASCII" has no such duplicate on its
+     own — `SynthCodePanel` mounts its own "Copy ASCII" action (next to its
+     code-snippet "Copy") specifically so this hide doesn't strand it. */
   :is(.dn-root--synth, .dn-root--generative) .synth-export-bar { display: none; }
 
   /* Export becomes a full bottom-drawer reachable via the Export tab —

--- a/website/src/components/SynthWorkbench/SynthCodePanel.tsx
+++ b/website/src/components/SynthWorkbench/SynthCodePanel.tsx
@@ -11,6 +11,12 @@ interface SynthCodePanelProps {
   onCodepen: () => void;
   exporting: boolean;
   onClose: () => void;
+  /** Copies the rendered ASCII art itself (distinct from `handleCopy` below,
+   *  which copies the generated CODE snippet). Mounted here too so the
+   *  action stays reachable once `.synth-export-bar` hides under 760px —
+   *  see instrument-workbench.css's mobile export rule. */
+  onCopyAscii: () => void;
+  copyAsciiState: "idle" | "copied" | "error";
 }
 
 /**
@@ -23,7 +29,7 @@ interface SynthCodePanelProps {
  * this component only mounts while shown, unlike the gallery's panel which
  * stays mounted and merely collapses its body.
  */
-export function SynthCodePanel({ id, className, input, onCodepen, exporting, onClose }: SynthCodePanelProps) {
+export function SynthCodePanel({ id, className, input, onCodepen, exporting, onClose, onCopyAscii, copyAsciiState }: SynthCodePanelProps) {
   const [tab, setTab] = useState<SynthTab>("react");
   const [copied, setCopied] = useState(false);
   const snippets = useMemo(() => generateSynthSnippets(input), [input]);
@@ -66,6 +72,14 @@ export function SynthCodePanel({ id, className, input, onCodepen, exporting, onC
           </button>
           <button type="button" className="gw-code-panel__action" onClick={handleCopy} title="Copy current snippet">
             {copied ? "Copied" : "Copy"}
+          </button>
+          <button
+            type="button"
+            className="gw-code-panel__action"
+            onClick={onCopyAscii}
+            title="Copy the rendered ASCII art to the clipboard"
+          >
+            {copyAsciiState === "copied" ? "Copied" : copyAsciiState === "error" ? "Copy failed" : "Copy ASCII"}
           </button>
           <button
             type="button"

--- a/website/src/components/SynthWorkbench/SynthWorkbench.tsx
+++ b/website/src/components/SynthWorkbench/SynthWorkbench.tsx
@@ -19,7 +19,7 @@ import {
   combineSynth,
   defaultGlyphEffectParams,
   GlyphRamps,
-  isGlyphFieldSynthStaticExportSupported,
+  glyphFieldSynthStaticExportUnsupportedReason,
   measureGlyphInkCoverage,
   synthWave,
 } from "@glyphcss/effects";
@@ -501,20 +501,24 @@ export default function SynthWorkbench() {
   // `buildGlyphFieldSynthStaticExport` explicitly REJECTS several patch
   // shapes it can't bake: volumetric/carve (a march per cell per frame is a
   // different export design — see AGENTS.md's "Static export"), an active
-  // `linearZ` voice, and a nonzero `originW` on an active voice (both
-  // 3D-only semantics with no meaning in the 2D branch this exporter ports).
-  // `isGlyphFieldSynthStaticExportSupported` is the exporter's OWN predicate (from
-  // `@glyphcss/effects`, mirroring `assertStaticExportSupported` exactly) —
-  // reading it here instead of duplicating the condition list means this
-  // button can never drift out of sync with what the exporter actually
-  // rejects (a URL-loaded patch can carry either of the latter two without
-  // being volumetric/carve, and used to slip past a narrower local check).
-  // The static "Open in CodePen" button below is disabled whenever this is
-  // false, instead of letting the exporter's throw reach the user; the
-  // "Export" code window's OWN CodePen action (`handleExportCodepenDynamic`)
-  // is unaffected — it mounts a LIVE effect at runtime from the CDN, which
-  // handles every one of these cases fine.
-  const staticExportSupported = useMemo(() => isGlyphFieldSynthStaticExportSupported(params), [params]);
+  // `linearZ` voice, a nonzero `originW` on an active voice (both 3D-only
+  // semantics with no meaning in the 2D branch this exporter ports), and
+  // `colorStackOn: true` (the colour voice stack has no inlined-runtime
+  // port). `glyphFieldSynthStaticExportUnsupportedReason` is the exporter's
+  // OWN predicate (from `@glyphcss/effects`, mirroring
+  // `assertStaticExportSupported`'s real throw sites, not a hand-mirrored
+  // condition list next to this button — reported bug: the disabled tooltip
+  // used to hard-code only the volumetric/linearZ/originW wording, so
+  // toggling the colour stack disabled the button but the tooltip kept
+  // naming reasons that didn't apply) — reading it here means this button
+  // (and its tooltip) can never drift out of sync with what the exporter
+  // actually rejects. The static "Open in CodePen" button below is disabled
+  // whenever this is non-null, instead of letting the exporter's throw reach
+  // the user; the "Export" code window's OWN CodePen action
+  // (`handleExportCodepenDynamic`) is unaffected — it mounts a LIVE effect
+  // at runtime from the CDN, which handles every one of these cases fine.
+  const staticExportUnsupportedReason = useMemo(() => glyphFieldSynthStaticExportUnsupportedReason(params), [params]);
+  const staticExportSupported = staticExportUnsupportedReason === null;
 
   // Builds the SAME static (zero-lib) export `buildGlyphFieldSynthStaticExport`
   // bakes for the standalone "Open in CodePen" button — reads the mesh, the
@@ -554,12 +558,19 @@ export default function SynthWorkbench() {
       projection: "orthographic",
       fontSizePx,
       lineHeightPx: rect.height > 0 && rows > 0 ? rect.height / rows : lineHeightPx,
+      // The SAME measured cell metrics `frameObject` (synthKit.tsx) used to
+      // fit `camera.zoom` against this exact `cols`/`rows` — without these,
+      // `bake()` reprojects that zoom onto its own headless BASE_TILE-derived
+      // cell size instead, baking a silhouette that covers the wrong
+      // fraction of the grid (see `GlyphFieldSynthStaticExportOptions`'s
+      // `cellWidthPx`/`cellHeightPx` doc).
+      cellWidthPx: rect.width > 0 && cols > 0 ? rect.width / cols : undefined,
+      cellHeightPx: rect.height > 0 && rows > 0 ? rect.height / rows : undefined,
       directionalLight: buildLighting(lighting).directionalLight,
       ambientLight: buildLighting(lighting).ambientLight,
       title: `glyphcss field synth — ${shape}`,
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shape, params, lighting, timeScale]);
+  }, [shape, params, lighting, timeScale, staticExportSupported]);
 
   // Standalone, always-visible "Open in CodePen" button (bottom-left): ships
   // the static, zero-lib baked pen (the ASCII the page currently renders +
@@ -670,9 +681,9 @@ export default function SynthWorkbench() {
               className="gw-code-panel__action gw-code-panel__action--codepen"
               onClick={handleExportCodepenStatic}
               disabled={exporting || !staticExportSupported}
-              title={staticExportSupported
+              title={staticExportUnsupportedReason === null
                 ? "Open the current rendered patch as a static, zero-runtime CodePen"
-                : "This patch can't bake to a static, zero-runtime CodePen — volumetric/carve (a march can't be prebaked per cell per frame), an active linearZ voice, or a nonzero origin W on an active voice all have no meaning in the baked 2D evaluator. Use \"Export\" instead, which ships a live effect from the CDN."}
+                : `Can't export a static, zero-runtime CodePen: ${staticExportUnsupportedReason} Use "Export" instead, which ships a live effect from the CDN.`}
             >
               {exporting ? "Exporting…" : "Open in CodePen"}
             </button>

--- a/website/src/components/SynthWorkbench/SynthWorkbench.tsx
+++ b/website/src/components/SynthWorkbench/SynthWorkbench.tsx
@@ -28,6 +28,7 @@ import { Dock } from "../Dock";
 import { useDockGui } from "../Dock/slots";
 import { useColor, useDockSlot, useFolder, useOption, useSlider, useText, useToggle } from "../Dock/primitives";
 import { SynthCodePanel } from "./SynthCodePanel";
+import { extractAsciiFromPre } from "../../lib/asciiClipboard";
 import { StatsOverlay } from "../StatsOverlay";
 import type { SynthSnippetInput } from "./synthSnippets";
 import { SYNTH_PARAM, decodeSynthUrlStateAsync, readInitialSynthState, writeSynthUrlState, type Lighting } from "./synthUrlState";
@@ -453,6 +454,33 @@ export default function SynthWorkbench() {
   const [exporting, setExporting] = useState(false);
   const [cameraSnapshot, setCameraSnapshot] = useState({ rotX: 0, rotY: 0, zoom: 46 });
 
+  // "Copy ASCII" (bottom-left export bar, next to "Open in CodePen"/"Export")
+  // copies the rendered ART ITSELF as plain text — distinct from
+  // `SynthCodePanel`'s own "Copy" button, which copies a generated CODE
+  // snippet. `extractAsciiFromPre` reads `textContent` (colored output's
+  // `<span>`s carry no markup through that) and trims each line's trailing
+  // grid-padding while preserving the art's own leading offset. A transient
+  // `copyState` mirrors `WordArtCodePanel`'s `copied` idiom, plus an explicit
+  // "error" state so a denied clipboard permission fails visibly instead of
+  // silently no-op-ing.
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+  const handleCopyAscii = useCallback(async () => {
+    const pre = hostRef.current?.querySelector("pre.glyph-output") as HTMLElement | null;
+    const text = extractAsciiFromPre(pre);
+    if (text === null) {
+      setCopyState("error");
+      setTimeout(() => setCopyState("idle"), 1500);
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyState("copied");
+    } catch {
+      setCopyState("error");
+    }
+    setTimeout(() => setCopyState("idle"), 1500);
+  }, []);
+
   const snapshotCamera = useCallback(() => {
     const camera = cameraRef.current;
     if (camera) setCameraSnapshot({ rotX: camera.rotX, rotY: camera.rotY, zoom: camera.zoom });
@@ -749,6 +777,14 @@ export default function SynthWorkbench() {
                 : `Can't export a static, zero-runtime CodePen: ${staticExportUnsupportedReason} Use "Export" instead, which ships a live effect from the CDN.`}
             >
               {exporting ? "Exporting…" : "Open in CodePen"}
+            </button>
+            <button
+              type="button"
+              className="gw-code-panel__action"
+              onClick={handleCopyAscii}
+              title="Copy the rendered ASCII art to the clipboard"
+            >
+              {copyState === "copied" ? "Copied" : copyState === "error" ? "Copy failed" : "Copy ASCII"}
             </button>
             <button
               type="button"

--- a/website/src/components/SynthWorkbench/SynthWorkbench.tsx
+++ b/website/src/components/SynthWorkbench/SynthWorkbench.tsx
@@ -482,12 +482,40 @@ export default function SynthWorkbench() {
     camera: cameraSnapshot,
   }), [shape, params, timeScale, paused, density, lighting, cameraSnapshot]);
 
-  /** POST a raw CodePen prefill `data` JSON payload (opens a new pen in a new tab). */
-  function postCodepenForm(action: string, data: string): void {
+  /**
+   * Open a blank, NAMED tab synchronously, inside the click gesture itself —
+   * before either export handler below does its (potentially multi-second,
+   * see `buildSynthExport`'s doc) synchronous bake. Chrome's transient user
+   * activation for a `target="_blank"` form POST expires a few seconds after
+   * the click; claiming the window up front sidesteps that entirely, since
+   * navigating an ALREADY-open window by name isn't a new-popup request and
+   * isn't subject to that limit — the standard pattern for slow popup work.
+   * Returns `null` only when the browser blocks even a same-gesture
+   * `window.open` (popups fully disabled for this origin); callers must tell
+   * the user, not fail silently the way a blocked `target="_blank"` POST did.
+   */
+  function openCodepenTab(name: string): Window | null {
+    const tab = window.open("", name);
+    if (tab) {
+      try {
+        tab.document.title = "Preparing CodePen…";
+        tab.document.body.textContent = "Building your pen…";
+        tab.document.body.style.cssText = "font:14px system-ui,sans-serif;color:#666;padding:2rem;";
+      } catch {
+        // Same-origin `about:blank` write can't actually throw here, but a
+        // future browser restriction on scripting a freshly opened window
+        // shouldn't take the tab (already open and about to navigate) down.
+      }
+    }
+    return tab;
+  }
+
+  /** POST a raw CodePen prefill `data` JSON payload into the tab `openCodepenTab` already opened. */
+  function postCodepenForm(action: string, data: string, targetName: string): void {
     const form = document.createElement("form");
     form.method = "POST";
     form.action = action;
-    form.target = "_blank";
+    form.target = targetName;
     const input = document.createElement("input");
     input.type = "hidden";
     input.name = "data";
@@ -575,47 +603,82 @@ export default function SynthWorkbench() {
   // Standalone, always-visible "Open in CodePen" button (bottom-left): ships
   // the static, zero-lib baked pen (the ASCII the page currently renders +
   // a pure-CSS loop) — no glyphcss/effects runtime.
+  //
+  // `buildSynthExport` (via `buildGlyphFieldSynthStaticExport`) bakes every
+  // covered cell's field-synth coordinate and can run into the seconds on a
+  // dense stage (measured ~4.2s at the live 202x78 default, worse at higher
+  // Density) — a plain synchronous call here would both freeze the page with
+  // no feedback AND risk losing Chrome's transient user activation before
+  // `postCodepenForm`'s POST fires, which is exactly "the button cannot be
+  // clicked" (the window silently never opens). `openCodepenTab` claims the
+  // destination tab FIRST, synchronously in the gesture, so the eventual POST
+  // is a same-window navigation, not a new-popup request, and can't be
+  // blocked by how long the bake takes. The `requestAnimationFrame` yield
+  // lets the "Exporting…" label actually paint before that synchronous bake
+  // begins, so the freeze that follows isn't silent.
   const handleExportCodepenStatic = useCallback(() => {
-    const result = buildSynthExport();
-    if (!result) return;
-    setExporting(true);
-    try {
-      postCodepenForm("https://codepen.io/pen/define", JSON.stringify({ title: `glyphcss field synth — ${shape}`, ...result.pen, editors: "110" }));
-    } finally {
-      setExporting(false);
+    const tab = openCodepenTab("glyphcss-codepen-static");
+    if (!tab) {
+      window.alert("Your browser blocked the new tab for this export. Allow popups for this site and try again.");
+      return;
     }
+    setExporting(true);
+    requestAnimationFrame(() => {
+      try {
+        const result = buildSynthExport();
+        if (!result) { tab.close(); return; }
+        postCodepenForm(
+          "https://codepen.io/pen/define",
+          JSON.stringify({ title: `glyphcss field synth — ${shape}`, ...result.pen, editors: "110" }),
+          "glyphcss-codepen-static",
+        );
+      } finally {
+        setExporting(false);
+      }
+    });
   }, [buildSynthExport, shape]);
 
   // "Export" code window's own CodePen action (and each framework tab):
   // compiles the current shape + camera + field-synth patch into a
   // self-contained, lib-based (glyphcss + @glyphcss/effects from the CDN)
-  // CodePen — mirrors the gallery's `handleCodepen`.
+  // CodePen — mirrors the gallery's `handleCodepen`. `buildGlyphInteractiveExport`
+  // is far cheaper than the static bake above (it decimates a polygon list,
+  // it doesn't march a cell grid), but it shares the same `postCodepenForm`
+  // popup-timing hazard, so it gets the same open-tab-first treatment for
+  // the same reason, not because it's independently been measured slow.
   const handleExportCodepenDynamic = useCallback(() => {
     const camera = cameraRef.current;
     if (!camera) return;
-    setExporting(true);
-    try {
-      const flat = isFlat(shape);
-      const result = buildGlyphInteractiveExport(shapePolys(shape), {
-        interactions: flat ? [] : ["orbit"],
-        rotX: camera.rotX,
-        rotY: camera.rotY,
-        zoom: camera.zoom,
-        projection: "orthographic",
-        mode: "solid",
-        useColors: true,
-        effect: {
-          id: fieldSynth.id,
-          params: params as Record<string, number | string | boolean>,
-          blend: SYNTH_EFFECT_BLEND,
-          timeScale: paused ? 0 : timeScale,
-        },
-      });
-      const prefill = glyphCodepenPrefill(result, `glyphcss field synth — ${shape}`);
-      postCodepenForm(prefill.action, prefill.data);
-    } finally {
-      setExporting(false);
+    const tab = openCodepenTab("glyphcss-codepen-dynamic");
+    if (!tab) {
+      window.alert("Your browser blocked the new tab for this export. Allow popups for this site and try again.");
+      return;
     }
+    setExporting(true);
+    requestAnimationFrame(() => {
+      try {
+        const flat = isFlat(shape);
+        const result = buildGlyphInteractiveExport(shapePolys(shape), {
+          interactions: flat ? [] : ["orbit"],
+          rotX: camera.rotX,
+          rotY: camera.rotY,
+          zoom: camera.zoom,
+          projection: "orthographic",
+          mode: "solid",
+          useColors: true,
+          effect: {
+            id: fieldSynth.id,
+            params: params as Record<string, number | string | boolean>,
+            blend: SYNTH_EFFECT_BLEND,
+            timeScale: paused ? 0 : timeScale,
+          },
+        });
+        const prefill = glyphCodepenPrefill(result, `glyphcss field synth — ${shape}`);
+        postCodepenForm(prefill.action, prefill.data, "glyphcss-codepen-dynamic");
+      } finally {
+        setExporting(false);
+      }
+    });
   }, [shape, params, paused, timeScale]);
 
   return (

--- a/website/src/components/SynthWorkbench/SynthWorkbench.tsx
+++ b/website/src/components/SynthWorkbench/SynthWorkbench.tsx
@@ -803,6 +803,8 @@ export default function SynthWorkbench() {
               onCodepen={handleExportCodepenDynamic}
               exporting={exporting}
               onClose={closeCodePanel}
+              onCopyAscii={handleCopyAscii}
+              copyAsciiState={copyState}
             />
           )}
         </InstrumentMain>

--- a/website/src/components/SynthWorkbench/synthKit.tsx
+++ b/website/src/components/SynthWorkbench/synthKit.tsx
@@ -2338,21 +2338,39 @@ export interface SynthStageHint {
 
 export const STAGE_HINTS: ReadonlyMap<GlyphEffectPreset<never>, SynthStageHint> = new Map([
   [GlyphCubeTilesPreset as GlyphEffectPreset<never>, { density: 1.5 }],
-  // Re-checked after the pyramid stage's upright reorientation
-  // (`shapeTransform`/`alignCornerTetraApexEuler` above): the old hint
-  // (rotX 35, rotY 40) was tuned to keep the origin corner in view alongside
-  // the far hypotenuse face on the PREVIOUS lying-on-a-face orientation —
-  // meaningless now that the mesh itself stands apex-up. The corner tetra's
-  // apex isn't always the single topmost screen pixel at every camera
-  // angle/roll (it's a lopsided "cube corner" shape, not a regular pyramid,
-  // and its recursive fractal detail — not a clean flat base — is what
-  // actually reads as "the interesting part"), so rather than chase a
-  // pixel-exact top vertex, this omits a custom angle entirely and falls
-  // back to the same default isometric-ish camera (rotX 58, rotY 32) every
-  // other non-special-cased volumetric shape already uses — visually
-  // verified centered and well-framed on the reoriented stage, and the
-  // Stage folder's auto-orbit (VOLUMETRIC-2.md §4) cycles the azimuth anyway.
-  [GlyphSierpinskiPyramidPreset as GlyphEffectPreset<never>, { shape: "pyramid" }],
+  // The reoriented corner tetra (`shapeTransform`/`alignCornerTetraApexEuler`
+  // above) has exact 3-fold rotational symmetry about world Z, so its
+  // rendered silhouette cycles every 120° of yaw (rotY) — confirmed by
+  // measurement, not assumption: a full-circle sweep at the shared default
+  // pitch (rotX 58) reproduces the identical taper at every yaw 120° apart.
+  // Within one 120° period only part of the range reads as a pyramid (apex
+  // narrow, widening monotonically to a wide base); the rest reads as a
+  // rhombus/diamond (narrow at both ends, wide in the middle) because the
+  // camera is looking at the tetra corner-on rather than down one of its
+  // sloped faces. The PREVIOUS entry omitted a custom angle and fell back to
+  // the default isometric camera (rotX 58, rotY 32) on the reasoning that it
+  // was "visually verified centered and well-framed" — it is centered, but
+  // rotY 32 lands squarely in the corner-on part of the cycle: measured
+  // per-row filled-span width is pointed at both ends and widest in the
+  // middle (rows 11-41, topAvg 56, botAvg 28, max 94, taper 0.51 — taper < 1
+  // means WIDENING toward the top-middle then narrowing again, the diamond
+  // the user reported, not a pyramid).
+  //
+  // rotY 225 (pitch unchanged at 58, so the module-level vertical-centering
+  // solve — calibrated at this exact pitch, see `solveVerticalCenteringZ`'s
+  // doc above — stays exact) lands on the sweet spot: per-row filled-span
+  // width grows by a constant 4 cells every single row from the apex down
+  // (rows 11-34: 2, 6, 10, ... 94 — perfectly monotonic, topAvg 16, botAvg
+  // 80, taper 5), col bbox exactly centered (0.0% offset), row bbox off by
+  // -6.7% (smaller than changing pitch away from 58 produces, and smaller
+  // than the ~4.4-4.8% col residual this table's own doc already accepts
+  // for this shape), and not clipped. The Stage folder's auto-orbit
+  // (VOLUMETRIC-2.md §4) still cycles the azimuth through the diamond part
+  // of the cycle too — inherent to a 3-fold-symmetric solid rotating in
+  // place, the same way a spinning cube shows different face combinations —
+  // but the preset now LOADS on a clean pyramid read instead of the
+  // corner-on one.
+  [GlyphSierpinskiPyramidPreset as GlyphEffectPreset<never>, { shape: "pyramid", rotX: 58, rotY: 225 }],
   // Time-animation preset (VOLUMETRIC-3.md, "we don't have any animation for
   // the volumetric ones") — the gyroid xray recipe with `speedN` turned on
   // (stock.ts). `paused` is deliberately left unset (default `false`): it

--- a/website/src/components/SynthWorkbench/synthUrlState.e2e.test.ts
+++ b/website/src/components/SynthWorkbench/synthUrlState.e2e.test.ts
@@ -124,6 +124,54 @@ function handBuiltPatch(): SynthPatch {
   };
 }
 
+// The v5 compact codec (website/src/lib/urlState.ts's run/list token
+// grammar) shrinks every REAL shipped preset well under the 400-char
+// compaction threshold (max measured: "Menger (cssGraphics)" at 239 chars,
+// down from 429 pre-v5 — that preset used to be the one that crossed the
+// threshold and is the whole reason this file's P0 regression test exists).
+// The compaction/`'z'`-link path is a real feature that still needs
+// coverage even though no shipped preset alone triggers it anymore — this
+// patch deliberately gives every per-voice-family key (angle/originU/
+// originV/duty/phase/originW × 9 voices, all layer/colour-stack keys) a
+// DISTINCT value so no run/list grouping applies, reliably landing over 400
+// chars (measured ~700) while staying schema-valid.
+function maximallyDistinctPatch(): SynthPatch {
+  const params: Params = {
+    ...handBuiltPatch().params,
+    field4: "angular", wave4: "sin", freq4: 2.2, speed4: 0.7, amp4: 0.25, color4: "#123456",
+    field5: "radial", wave5: "triangle", freq5: 4.4, speed5: -0.9, amp5: 0.45, color5: "#654321",
+    field6: "linearY", wave6: "saw", freq6: 1.7, speed6: 0.3, amp6: 0.55, color6: "#abcdef",
+    angle1: 5, angle2: 15, angle3: 25, angle4: 35, angle5: 45, angle6: 55, angle7: 65, angle8: 75, angle9: 85,
+    originU1: 0.01, originU2: 0.02, originU3: 0.03, originU4: 0.04, originU5: 0.05, originU6: 0.06, originU7: 0.07, originU8: 0.08, originU9: 0.09,
+    originV1: 0.11, originV2: 0.12, originV3: 0.13, originV4: 0.14, originV5: 0.15, originV6: 0.16, originV7: 0.17, originV8: 0.18, originV9: 0.19,
+    duty1: 0.21, duty2: 0.22, duty3: 0.23, duty4: 0.24, duty5: 0.25, duty6: 0.26, duty7: 0.27, duty8: 0.28, duty9: 0.29,
+    phase1: 0.31, phase2: 0.32, phase3: 0.33, phase4: 0.34, phase5: 0.35, phase6: 0.36, phase7: 0.37, phase8: 0.38, phase9: 0.39,
+    originW1: 0.41, originW2: 0.42, originW3: 0.43, originW4: 0.44, originW5: 0.45, originW6: 0.46, originW7: 0.47, originW8: 0.48, originW9: 0.49,
+    layer1: 1, layer2: 2, layer3: 3, layer4: 1, layer5: 2, layer6: 3, layer7: 1, layer8: 2, layer9: 3,
+    layerCombine1: "add", layerCombine2: "max", layerCombine3: "min",
+    layerThresholdOn1: true, layerThresholdOn2: false, layerThresholdOn3: true,
+    layerThreshold1: 0.5, layerThreshold2: -0.5, layerThreshold3: 1.2,
+    layerInvert1: true, layerInvert2: false, layerInvert3: false,
+    layerBlend1: "add", layerBlend2: "min", layerBlend3: "difference",
+    layerAmp1: 0.3, layerAmp2: 0.6, layerAmp3: 0.9,
+    cphase1: 0.11, cangle1: 11, coriginU1: 0.11, coriginV1: 0.12, coriginW1: 0.13, cduty1: 0.31, citer1: 1,
+    cphase2: 0.21, cangle2: 21, coriginU2: 0.21, coriginV2: 0.22, coriginW2: 0.23, cduty2: 0.32, citer2: 2,
+    cphase3: 0.31, cangle3: 31, coriginU3: 0.31, coriginV3: 0.32, coriginW3: 0.33, cduty3: 0.33, citer3: 3,
+    inkSpacing: 0.11,
+    inkLevels: 3,
+    subcellRes: "1x1",
+  };
+  return {
+    shape: "sphere",
+    params,
+    timeScale: 2.1,
+    density: 1.8,
+    colorTolerance: SYNTH_URL_DEFAULTS.colorTolerance,
+    lighting: REPRESENTATIVE_LIGHTING,
+    voiceSlots: voiceSlotsFromParams(params),
+  };
+}
+
 function stepFor(key: string): number {
   const spec = (fieldSynth.parameterSchema as unknown as Record<string, { step?: number }>)[key];
   return spec?.step && spec.step > 0 ? spec.step : 0.0001;
@@ -199,17 +247,17 @@ beforeEach(() => {
 
 describe("synth URL codec — real entry-point round trip (P0 regression)", () => {
   it("demonstrates the bug mechanism: sync-only read loses a compacted link the async catch-up recovers", async () => {
-    // The exact reported repro: click "Menger (cssGraphics)", read the URL,
-    // reload. Not hand-built — pulled from the real shipped preset list so
-    // this test tracks the actual patch, not a stand-in guessed to be big
-    // enough.
-    const mengerCssGraphics = (fieldSynth.presets ?? []).find((p) => p.name.includes("cssGraphics"));
-    if (!mengerCssGraphics) throw new Error('expected a shipped "Menger (cssGraphics)" preset');
-    const patch = presetPatch(mengerCssGraphics, "cube");
+    // Originally reproduced with the shipped "Menger (cssGraphics)" preset
+    // (colour stack + several geometry/colour voices used to pack to 429
+    // chars, crossing the compaction threshold in real use — that's WHY the
+    // reported link broke on this preset and not a small one). The v5
+    // compact codec shrinks that SAME preset to 239 chars — well under the
+    // threshold now (see synthUrlState.test.ts's real-preset-length
+    // regression coverage) — so the mechanism this test exists to guard is
+    // exercised instead with `maximallyDistinctPatch()`, a patch built to
+    // reliably still cross 400 chars post-shrink (see that helper's doc).
+    const patch = maximallyDistinctPatch();
     const expectedPacked = encodeSynthUrlState(patch);
-    // This preset (colour stack + several geometry/colour voices) is exactly
-    // the shape that crosses the compaction threshold in real use — that's
-    // WHY the reported link broke on this preset and not a small one.
     expect(expectedPacked.length).toBeGreaterThan(400);
 
     writeSynthUrlState(patch);
@@ -236,6 +284,12 @@ describe("synth URL codec — real entry-point round trip (P0 regression)", () =
     expectPatchesMatch(restored, patch);
   });
 
+  it("round-trips the maximally-distinct (>400 char, 'z'-compacted) patch through the real write/read path", async () => {
+    const patch = maximallyDistinctPatch();
+    const restored = await roundTripThroughRealUrl(patch);
+    expectPatchesMatch(restored, patch);
+  });
+
   for (const preset of fieldSynth.presets ?? []) {
     it(`round-trips the "${preset.name}" preset through the real write/read path`, async () => {
       const patch = presetPatch(preset, "cube");
@@ -244,8 +298,15 @@ describe("synth URL codec — real entry-point round trip (P0 regression)", () =
     });
   }
 
-  it("covers both packed forms across the shipped presets (not just always-'p' or always-'z')", () => {
-    const lengths = (fieldSynth.presets ?? []).map((preset) => encodeSynthUrlState(presetPatch(preset, "cube")).length);
+  it("covers both packed forms (not just always-'p' or always-'z')", () => {
+    // Every shipped preset now packs to <= 400 chars post-v5 (the whole
+    // point of the shrink — see `maximallyDistinctPatch()`'s doc above), so
+    // "both forms reachable" is no longer provable from the shipped preset
+    // set alone; `maximallyDistinctPatch()` stands in for the >400 case.
+    const lengths = [
+      ...(fieldSynth.presets ?? []).map((preset) => encodeSynthUrlState(presetPatch(preset, "cube")).length),
+      encodeSynthUrlState(maximallyDistinctPatch()).length,
+    ];
     expect(lengths.some((n) => n <= 400)).toBe(true);
     expect(lengths.some((n) => n > 400)).toBe(true);
   });

--- a/website/src/components/SynthWorkbench/synthUrlState.test.ts
+++ b/website/src/components/SynthWorkbench/synthUrlState.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 import {
   GLYPH_FIELD_SYNTH_VALIDATION_RULES,
   GlyphFieldSynthEffect as fieldSynth,
+  GlyphCubeTilesPreset,
+  GlyphSierpinskiPyramidPreset,
+  GlyphBreathingGyroidPreset,
+  GlyphCssGraphicsMengerPreset,
+  defaultGlyphEffectParams,
 } from "@glyphcss/effects";
-import { createUrlCodec, encodeEffectParamsPacked } from "../../lib/urlState";
+import { createUrlCodec, encodeEffectParamsPackedLegacy } from "../../lib/urlState";
 import {
   COERCION_HANDLED_RULES,
   LEGACY_V2_FIELD_SYNTH_SCHEMA,
@@ -59,7 +64,7 @@ describe("synth url state", () => {
       lighting: { azimuth: 40, elevation: 38, keyIntensity: 1.1, keyColor: "#ffffff", ambient: 0.5 },
       voiceSlots: [1, 2],
     });
-    expect(packed).toBe("p4");
+    expect(packed).toBe("p5");
   });
 
   it("round-trips a representative multi-voice patch", () => {
@@ -205,13 +210,13 @@ describe("colorTolerance round-trips (COLOR-TOLERANCE.md Phase 4, replaces color
 });
 
 // ── Acceptance 7 (VOLUMETRIC.md): the URL codec's schema-index cap ─────────
-// `encodeEffectParamsPacked` keyed params by a single base62 char, capping at
-// index 61. `fieldSynthSchema` is well past 120 keys, so every param below —
-// `lit`/`voiceColors`/`color1..6` (pre-existing, silently dropped before this
+// `encodeEffectParamsPacked` keys params by position in `fieldSynthSchema`
+// (well past 200 keys). A single direct char only reaches index 58 (index 61
+// under the legacy pre-v5 codec); every param below — `lit`/`voiceColors`/
+// `color1..6` (pre-existing, silently dropped before the original escape
 // fix) and every VOLUMETRIC.md param (layers, duty, phase, originW, render,
 // marchSteps, marchFade) — lands past that cap and needs the multi-char index
-// escape (`encodeTokenIndex`/`decodeTokenIndex` in `../../lib/urlState`) to
-// round-trip at all.
+// escape in `../../lib/urlState` to round-trip at all.
 function everyNewParamPatch(): { shape: string; params: Params; timeScale: number; density: number; colorTolerance: number; lighting: Lighting; voiceSlots: number[] } {
   const base = representativePatch();
   return {
@@ -317,7 +322,7 @@ function maskFromSlots(slots: readonly number[]): number {
 const LEGACY_V2_DEFAULTS: Params = { ...SYNTH_PARAM_DEFAULTS, slabAxis: "none", slabStart: -1, slabEnd: 1 };
 const legacyV2OuterCodec = createUrlCodec<SynthUrlState>("2", synthCodec.fields);
 function encodeLegacyV2(state: ReturnType<typeof representativePatch>, legacyParams: Params): string {
-  const paramsPacked = encodeEffectParamsPacked(LEGACY_V2_FIELD_SYNTH_SCHEMA, LEGACY_V2_DEFAULTS, legacyParams);
+  const paramsPacked = encodeEffectParamsPackedLegacy(LEGACY_V2_FIELD_SYNTH_SCHEMA, LEGACY_V2_DEFAULTS, legacyParams);
   return legacyV2OuterCodec.encode({
     shape: state.shape,
     timeScale: state.timeScale,
@@ -371,10 +376,10 @@ describe("synth url state — v2 legacy decode (post-slab-removal)", () => {
     }
   });
 
-  it("v4 (current) links round-trip and are tagged \"p4\"", () => {
+  it("v5 (current) links round-trip and are tagged \"p5\"", () => {
     const patch = representativePatch();
     const packed = encodeSynthUrlState(patch);
-    expect(packed[1]).toBe("4");
+    expect(packed[1]).toBe("5");
     const restored = decodeSynthUrlState(packed);
     expect("slabAxis" in restored.params).toBe(false);
     expect("colorQuantize" in restored.params).toBe(false);
@@ -409,7 +414,7 @@ describe("synth url state — v2 legacy decode (post-slab-removal)", () => {
 const LEGACY_V3_DEFAULTS: Params = { ...SYNTH_PARAM_DEFAULTS, colorQuantize: 0 };
 const legacyV3OuterCodec = createUrlCodec<SynthUrlState>("3", synthCodec.fields);
 function encodeLegacyV3(state: ReturnType<typeof representativePatch>, legacyParams: Params): string {
-  const paramsPacked = encodeEffectParamsPacked(LEGACY_V3_FIELD_SYNTH_SCHEMA, LEGACY_V3_DEFAULTS, legacyParams);
+  const paramsPacked = encodeEffectParamsPackedLegacy(LEGACY_V3_FIELD_SYNTH_SCHEMA, LEGACY_V3_DEFAULTS, legacyParams);
   return legacyV3OuterCodec.encode({
     shape: state.shape,
     timeScale: state.timeScale,
@@ -446,7 +451,7 @@ describe("synth url state — v3 legacy decode (post-colorQuantize-removal, COLO
     expect(() => fieldSynth.program.validateParams?.({ ...restored.params, time: 0 } as never)).not.toThrow();
   });
 
-  it("a v3 URL without any colorQuantize override decodes identically to the equivalent v4 link", () => {
+  it("a v3 URL without any colorQuantize override decodes identically to the equivalent current link", () => {
     const patch = representativePatch();
     const packedLegacy = encodeLegacyV3(patch, patch.params);
     const packedCurrent = encodeSynthUrlState(patch);
@@ -463,6 +468,133 @@ describe("synth url state — v3 legacy decode (post-colorQuantize-removal, COLO
       }
     }
   });
+});
+
+// ── Compact codec rewrite: SYNTH_SCHEMA_VERSION 4 -> 5 (website/src/lib/
+//    urlState.ts's run/list token grammar) ─────────────────────────────────
+// Unlike every bump above, v5 does NOT change which schema keys exist or
+// their order — `paramsSchemaFor` in synthUrlState.ts routes a "4"-tagged
+// link to the SAME (current) schema a "5"-tagged link uses. What changed is
+// the WIRE FORMAT of `paramsPacked` itself: a v4 link was packed with the
+// legacy per-key escaped-index grammar (`encodeEffectParamsPackedLegacy`),
+// while v5 packs with the compact run/list grammar
+// (`encodeEffectParamsPacked`). A "4"-tagged link must therefore decode
+// `paramsPacked` through the LEGACY decoder even though it reads the CURRENT
+// key order — see `decodeParamsPacked` in synthUrlState.ts, which is exactly
+// why that dispatch is separate from `paramsSchemaFor`'s key-order dispatch.
+const legacyV4OuterCodec = createUrlCodec<SynthUrlState>("4", synthCodec.fields);
+function encodeLegacyV4(state: ReturnType<typeof representativePatch>, legacyParams: Params): string {
+  const paramsPacked = encodeEffectParamsPackedLegacy(fieldSynth.parameterSchema as never, SYNTH_PARAM_DEFAULTS, legacyParams);
+  return legacyV4OuterCodec.encode({
+    shape: state.shape,
+    timeScale: state.timeScale,
+    density: state.density,
+    voiceSlotMask: maskFromSlots(state.voiceSlots),
+    lightAzimuth: state.lighting.azimuth,
+    lightElevation: state.lighting.elevation,
+    lightKeyIntensity: state.lighting.keyIntensity,
+    lightKeyColor: state.lighting.keyColor,
+    lightAmbient: state.lighting.ambient,
+    colorTolerance: state.colorTolerance,
+    paramsPacked,
+  });
+}
+
+describe("synth url state — v4 legacy decode (pre-compact-codec, wire format only)", () => {
+  it("a genuinely v4-tagged link (legacy escape grammar) decodes identically to the equivalent v5 link", () => {
+    const patch = representativePatch();
+    const packedLegacy = encodeLegacyV4(patch, patch.params);
+    expect(packedLegacy[1]).toBe("4"); // sanity: genuinely v4-tagged
+    const packedCurrent = encodeSynthUrlState(patch);
+    expect(packedCurrent[1]).toBe("5");
+    const restoredLegacy = decodeSynthUrlState(packedLegacy);
+    const restoredCurrent = decodeSynthUrlState(packedCurrent);
+    for (const [key, value] of Object.entries(patch.params)) {
+      if (key === "time") continue;
+      if (typeof value === "number") {
+        expect(restoredLegacy.params[key], key).toBeCloseTo(value, 3);
+        expect(restoredLegacy.params[key], key).toBeCloseTo(restoredCurrent.params[key] as number, 3);
+      } else {
+        expect(restoredLegacy.params[key], key).toBe(value);
+        expect(restoredLegacy.params[key], key).toBe(restoredCurrent.params[key]);
+      }
+    }
+  });
+
+  // Real v4 links, captured from THIS repo's code BEFORE the v5 compact-codec
+  // change landed (encoded with the then-current `encodeSynthUrlState`, not
+  // hand-built) — the strongest proof available that an already-shared link
+  // keeps decoding to exactly the state it always did. `expectedPatch`
+  // reconstructs the same patch `SynthWorkbench.tsx`'s `applyPreset` builds
+  // (preset params merged over the live schema defaults), independent of any
+  // codec, so this isn't a tautological encode-then-decode check.
+  function synthSchemaDefaults(): Params {
+    const { time: _time, ...rest } = defaultGlyphEffectParams(fieldSynth) as Params;
+    return rest;
+  }
+  function voiceSlotsFromParams(params: Params): number[] {
+    return Array.from({ length: MAX_VOICES }, (_, i) => i + 1).filter((k) => Number(params[`amp${k}`] ?? 0) > 0);
+  }
+  const FIXTURE_LIGHTING: Lighting = { azimuth: 120, elevation: 60, keyIntensity: 1.5, keyColor: "#ffddaa", ambient: 0.3 };
+  function expectedPatch(preset: { params: Partial<Params> }): { shape: string; params: Params; timeScale: number; density: number; colorTolerance: number; lighting: Lighting; voiceSlots: number[] } {
+    const params = { ...synthSchemaDefaults(), ...(preset.params as Params) };
+    return {
+      shape: "cube",
+      params,
+      timeScale: SYNTH_URL_DEFAULTS.timeScale,
+      density: 1,
+      colorTolerance: SYNTH_URL_DEFAULTS.colorTolerance,
+      lighting: FIXTURE_LIGHTING,
+      voiceSlots: voiceSlotsFromParams(params),
+    };
+  }
+
+  const REAL_V4_FIXTURES: readonly { name: string; preset: { params: Partial<Params> }; packed: string }[] = [
+    { name: "GlyphCubeTilesPreset", preset: GlyphCubeTilesPreset, packed: "p4s1v17a23ce21ok1uK9zelmm16p2b.223c516171a81cd1e1f1ag16i21om1n1ao2-6p1kq23cR5S21oT1kU3.░▒█_129k2yc_1385bdc_1446vzf" },
+    { name: "GlyphSierpinskiPyramidPreset", preset: GlyphSierpinskiPyramidPreset, packed: "p4s1v21ra23ce21ok1uK9zelmm16p5c.13516371a810d2e3f1ag10l7m3n1ao10p1kt1u3v1kw10x1kB2C3D1kE10F1kJ7K3L1kM10N1kX9z6foY9ypb6Z18_110_1e3-1e_1f3-1e_1g3-1e_1h3-1e_1i3-1e_1j3-1e_1t12_1u12_1v12_1w0_1x0_1z1_1A1_1F1_1G1_1I3_1J3_1O1_1Q214" },
+    { name: "GlyphBreathingGyroidPreset", preset: GlyphBreathingGyroidPreset, packed: "p4s1v11a23ce21ok1uK9zelmm16p1d.132145871f813h10X5m22nY7v94vZ1c_110_1z1_1O2_1R21o" },
+    { name: "GlyphCssGraphicsMengerPreset", preset: GlyphCssGraphicsMengerPreset, packed: "p4s1v2e7a23ce21ok1uK9zelmm16pb1.13217516371a810d2e3f1ag10l7m3n1ao10p1kt1u3v1uw10x1kB2C3D1uE10F1kJ7K3L1uM10N1kX5f8w1Y2a2nkZ18_110_181x_191x_1a1x_1b1x_1c1x_1d1x_1e2-x_1f2-x_1g2-x_1h2-x_1i2-x_1j2-x_1t12_1u12_1v12_1w0_1x0_1y0_1z1_1A1_1B1_1F1_1G1_1H1_1I3_1J3_1K3_1O1_1P11_1Q1r_1Z1_202_217_223_233_243_2522i_2622i_2722i_2810_2910_2a10_2b1k_2c1k_2d1k_2q1x_2r1x_2s1x_2t2-x_2u2-x_2v2-x_2z13_2A13_2B13_2F1_2H1_2K219_2L21o_2Me_2P2_2S1a_2V10" },
+  ];
+
+  for (const fixture of REAL_V4_FIXTURES) {
+    it(`decodes the real captured v4 link for "${fixture.name}" to exactly its pre-change state`, () => {
+      expect(fixture.packed[1]).toBe("4");
+      const restored = decodeSynthUrlState(fixture.packed);
+      const expected = expectedPatch(fixture.preset);
+      expect(restored.shape).toBe(expected.shape);
+      expect(restored.timeScale).toBeCloseTo(expected.timeScale, 5);
+      expect(restored.density).toBeCloseTo(expected.density, 5);
+      expect(restored.colorTolerance).toBeCloseTo(expected.colorTolerance, 5);
+      expect(restored.lighting).toEqual(expected.lighting);
+      expect(restored.voiceSlots).toEqual(expected.voiceSlots);
+      for (const [key, value] of Object.entries(expected.params)) {
+        if (key === "time") continue;
+        if (typeof value === "number") {
+          // Quantized to the field's own step (e.g. `duty: 1/3` legitimately
+          // rounds to 0.33 at duty's step-0.01 precision, on BOTH the real
+          // v4 link and any fresh encode) — compare against that quantized
+          // value, not the raw preset literal, or a repeating-decimal
+          // default (exactly this Menger recipe's `duty1: 1/3`) reads as a
+          // false mismatch.
+          const spec = (fieldSynth.parameterSchema as Record<string, { step?: number }>)[key];
+          const step = spec?.step && spec.step > 0 ? spec.step : 0.0001;
+          const quantized = Math.round(value / step) * step;
+          expect(restored.params[key], key).toBeCloseTo(quantized, 3);
+        } else {
+          expect(restored.params[key], key).toBe(value);
+        }
+      }
+    });
+
+    it(`re-encodes "${fixture.name}" shorter than its captured v4 length`, () => {
+      const expected = expectedPatch(fixture.preset);
+      const reencoded = encodeSynthUrlState(expected);
+      expect(reencoded[1]).toBe("5");
+      expect(reencoded.length).toBeLessThan(fixture.packed.length);
+      // eslint-disable-next-line no-console
+      console.log(`${fixture.name}: v4 ${fixture.packed.length} chars -> v5 ${reencoded.length} chars`);
+    });
+  }
 });
 
 // ── Final-gate fix: cross-field-invalid {space, render} hydration ──────────

--- a/website/src/components/SynthWorkbench/synthUrlState.ts
+++ b/website/src/components/SynthWorkbench/synthUrlState.ts
@@ -18,6 +18,7 @@ import {
 import {
   createUrlCodec,
   decodeEffectParamsPacked,
+  decodeEffectParamsPackedLegacy,
   encodeEffectParamsPacked,
   readUrlParam,
   scheduleCompactedUrlWrite,
@@ -186,11 +187,14 @@ function buildLegacyV3FieldSynthSchema(): EffectParamSchemaLike {
 }
 export const LEGACY_V3_FIELD_SYNTH_SCHEMA: EffectParamSchemaLike = buildLegacyV3FieldSynthSchema();
 
-// Bumped 3 -> 4 for the colorQuantize removal above (an inner-schema
-// key-shrink, not the 1 -> 2 escape-format fix or the 2 -> 3 slab removal
-// below): the OUTER `?s=` version tag is what routes a link's `paramsPacked`
-// to the right key order at decode time (see `decodeSynthUrlState`).
-const SYNTH_SCHEMA_VERSION = "4";
+// Bumped 4 -> 5 for the shared codec's compact-index/run/list rewrite of
+// `encodeEffectParamsPacked`/`decodeEffectParamsPacked` (website/src/lib/
+// urlState.ts) — a wire-format change to `paramsPacked` itself (not a
+// schema key reshuffle like the 2->3/3->4 bumps below), so a v4 link's
+// `paramsPacked` must decode through the LEGACY pair
+// (`decodeEffectParamsPackedLegacy`) against the CURRENT schema — v4 never
+// changed which keys exist, only v5 changes how they're packed.
+const SYNTH_SCHEMA_VERSION = "5";
 export const synthCodec = createUrlCodec<SynthUrlState>(SYNTH_SCHEMA_VERSION, synthFields);
 // Decodes a URL shared before the version bump (`raw[1] === "1"`). Same field
 // list — only `paramsPacked`'s internal token format changed, and that change
@@ -211,6 +215,12 @@ const synthCodecLegacyV2 = createUrlCodec<SynthUrlState>("2", synthFields);
 // default, exactly as intended), but `paramsPacked` must be decoded against
 // `LEGACY_V3_FIELD_SYNTH_SCHEMA`'s old key order.
 const synthCodecLegacyV3 = createUrlCodec<SynthUrlState>("3", synthFields);
+// Decodes a "4"-tagged link (the version live from the colorQuantize removal
+// through the v5 compact-codec rewrite) — same outer field list AND the same
+// (current) `paramsPacked` key order as v5, but `paramsPacked` itself must be
+// decoded with the LEGACY escape-based decoder (see `decodeParamsPacked`
+// below), since v5 is the first version to write the compact grammar.
+const synthCodecLegacyV4 = createUrlCodec<SynthUrlState>("4", synthFields);
 export const SYNTH_PARAM = "s";
 
 // Shared with `resolveSpaceChange` in synthKit.tsx (the live Mapping-dropdown
@@ -445,23 +455,43 @@ export function encodeSynthUrlState(state: SynthPatch): string {
   });
 }
 
-/** Dispatches to the legacy (pre-bump) codec for a "1"/"2"/"3"-tagged link,
- *  else the live codec — see `SYNTH_SCHEMA_VERSION`'s doc. */
+/** Dispatches to the legacy (pre-bump) codec for a "1"/"2"/"3"/"4"-tagged
+ *  link, else the live codec — see `SYNTH_SCHEMA_VERSION`'s doc. */
 function decodeOuterState(raw: string | null | undefined): Partial<SynthUrlState> {
   if (raw && raw[1] === "1") return synthCodecLegacyV1.decode(raw);
   if (raw && raw[1] === "2") return synthCodecLegacyV2.decode(raw);
   if (raw && raw[1] === "3") return synthCodecLegacyV3.decode(raw);
+  if (raw && raw[1] === "4") return synthCodecLegacyV4.decode(raw);
   return synthCodec.decode(raw);
 }
 
-/** "1"/"2"-tagged links predate the slab removal, and "3"-tagged links
+/** "1"/"2"-tagged links predate the slab removal, and "3"/"4"-tagged links
  *  predate the colorQuantize removal — each must decode `paramsPacked`
  *  against its OWN old key order (`LEGACY_V2_FIELD_SYNTH_SCHEMA` /
- *  `LEGACY_V3_FIELD_SYNTH_SCHEMA`'s docs). */
+ *  `LEGACY_V3_FIELD_SYNTH_SCHEMA`'s docs). A "4"-tagged link's key order is
+ *  identical to the live schema (only the wire FORMAT changed for v5, see
+ *  `decodeParamsPacked` below), so it shares the same branch as the current
+ *  (v5) schema here. */
 function paramsSchemaFor(raw: string | null | undefined): EffectParamSchemaLike {
   if (raw && (raw[1] === "1" || raw[1] === "2")) return LEGACY_V2_FIELD_SYNTH_SCHEMA;
   if (raw && raw[1] === "3") return LEGACY_V3_FIELD_SYNTH_SCHEMA;
   return fieldSynth.parameterSchema as unknown as EffectParamSchemaLike;
+}
+
+/** Every version below the current one wrote `paramsPacked` with the LEGACY
+ *  escape-based grammar (`encodeEffectParamsPackedLegacy`); only
+ *  `SYNTH_SCHEMA_VERSION` ("5") writes/reads the compact run/list grammar
+ *  (`encodeEffectParamsPacked`). This is a wire-format dispatch, orthogonal
+ *  to `paramsSchemaFor`'s key-ORDER dispatch above — a "4"-tagged link uses
+ *  the CURRENT key order but the LEGACY format, which is exactly why this
+ *  needs its own check rather than folding into `paramsSchemaFor`. */
+function decodeParamsPacked(
+  raw: string | null | undefined,
+  schema: EffectParamSchemaLike,
+  packed: string | undefined,
+): Record<string, unknown> {
+  if (raw && raw[1] === SYNTH_SCHEMA_VERSION) return decodeEffectParamsPacked(schema, packed);
+  return decodeEffectParamsPackedLegacy(schema, packed);
 }
 
 /** Shared post-processing for BOTH the synchronous ('p') and async ('z')
@@ -474,7 +504,7 @@ function paramsSchemaFor(raw: string | null | undefined): EffectParamSchemaLike 
  *  `codec.decode`, async via `codec.decodeAsync`). */
 function buildSynthInitialState(raw: string | null | undefined, outer: Partial<SynthUrlState>): SynthInitialState {
   const decoded = { ...SYNTH_URL_DEFAULTS, ...outer };
-  const overrides = decodeEffectParamsPacked(paramsSchemaFor(raw), decoded.paramsPacked);
+  const overrides = decodeParamsPacked(raw, paramsSchemaFor(raw), decoded.paramsPacked);
   // The retired slab keys only ever appear when `overrides` was decoded
   // against `LEGACY_V2_FIELD_SYNTH_SCHEMA` (a "1"/"2"-tagged link), and
   // `colorQuantize` only when decoded against `LEGACY_V3_FIELD_SYNTH_SCHEMA`
@@ -521,6 +551,7 @@ function outerCodecFor(raw: string | null | undefined) {
   if (raw && raw[1] === "1") return synthCodecLegacyV1;
   if (raw && raw[1] === "2") return synthCodecLegacyV2;
   if (raw && raw[1] === "3") return synthCodecLegacyV3;
+  if (raw && raw[1] === "4") return synthCodecLegacyV4;
   return synthCodec;
 }
 

--- a/website/src/components/WordArtWorkbench/WordArtCodePanel.tsx
+++ b/website/src/components/WordArtWorkbench/WordArtCodePanel.tsx
@@ -11,6 +11,12 @@ interface WordArtCodePanelProps {
   onCodepen: () => void;
   exporting: boolean;
   onClose: () => void;
+  /** Copies the rendered ASCII art itself (distinct from `handleCopy` below,
+   *  which copies the generated CODE snippet). Mounted here too so the
+   *  action stays reachable once `.wa-export-bar` hides under 760px — see
+   *  wordart.css's mobile export rule. */
+  onCopyAscii: () => void;
+  copyAsciiState: "idle" | "copied" | "error";
 }
 
 /**
@@ -22,7 +28,7 @@ interface WordArtCodePanelProps {
  * Visibility is owned by the parent (`WordArtWorkbench`'s `codeOpen` / mobile
  * "Export" tab) — this component only mounts while shown.
  */
-export function WordArtCodePanel({ id, className, input, onCodepen, exporting, onClose }: WordArtCodePanelProps) {
+export function WordArtCodePanel({ id, className, input, onCodepen, exporting, onClose, onCopyAscii, copyAsciiState }: WordArtCodePanelProps) {
   const [tab, setTab] = useState<WordArtTab>("react");
   const [copied, setCopied] = useState(false);
   const snippets = useMemo(() => generateWordArtSnippets(input), [input]);
@@ -65,6 +71,14 @@ export function WordArtCodePanel({ id, className, input, onCodepen, exporting, o
           </button>
           <button type="button" className="gw-code-panel__action" onClick={handleCopy} title="Copy current snippet">
             {copied ? "Copied" : "Copy"}
+          </button>
+          <button
+            type="button"
+            className="gw-code-panel__action"
+            onClick={onCopyAscii}
+            title="Copy the rendered ASCII art to the clipboard"
+          >
+            {copyAsciiState === "copied" ? "Copied" : copyAsciiState === "error" ? "Copy failed" : "Copy ASCII"}
           </button>
           <button
             type="button"

--- a/website/src/components/WordArtWorkbench/WordArtWorkbench.tsx
+++ b/website/src/components/WordArtWorkbench/WordArtWorkbench.tsx
@@ -52,6 +52,7 @@ import {
 } from "../GalleryWorkbench/effects";
 import type { GalleryEffectBlend, GalleryEffectParamValue, GalleryEffectState } from "../GalleryWorkbench/types";
 import { WordArtCodePanel } from "./WordArtCodePanel";
+import { extractAsciiFromPre } from "../../lib/asciiClipboard";
 import { buildWordArtCodepenPen } from "./wordartSnippets";
 import {
   readInitialWordArtState,
@@ -399,6 +400,35 @@ export function WordArtWorkbench() {
   const [exporting, setExporting] = useState(false);
   const stageSnapshotRef = useRef<{ rotation: Vec3; zoom: number }>({ rotation: [0, 14, 0], zoom: 3 });
   const [stageSnapshot, setStageSnapshot] = useState<{ rotation: Vec3; zoom: number }>({ rotation: [0, 14, 0], zoom: 3 });
+
+  // "Copy ASCII" (bottom-left export bar, next to "Open in CodePen"/"Export")
+  // copies the rendered ART ITSELF as plain text — distinct from
+  // `WordArtCodePanel`'s own "Copy" button, which copies a generated CODE
+  // snippet. Same `.wa-stage pre.glyph-output` scoping
+  // `handleExportCodepenStatic` already uses below (the preset tiles render
+  // their own `pre.glyph-output` outside `.wa-stage`, so this selector can't
+  // pick one of those up). `extractAsciiFromPre` reads `textContent` (no
+  // `<span>` markup) and trims each line's trailing grid-padding while
+  // preserving the art's own leading offset. Mirrors `SynthWorkbench`'s
+  // `copyState` idiom, including the explicit "error" state for a denied
+  // clipboard permission.
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+  const handleCopyAscii = useCallback(async () => {
+    const pre = document.querySelector(".wa-stage pre.glyph-output") as HTMLElement | null;
+    const text = extractAsciiFromPre(pre);
+    if (text === null) {
+      setCopyState("error");
+      setTimeout(() => setCopyState("idle"), 1500);
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyState("copied");
+    } catch {
+      setCopyState("error");
+    }
+    setTimeout(() => setCopyState("idle"), 1500);
+  }, []);
 
   useEffect(() => {
     if (!mobilePanel) return;
@@ -1034,6 +1064,14 @@ export function WordArtWorkbench() {
               title="Open the current rendered word art as a static, zero-runtime CodePen"
             >
               {exporting ? "Exporting…" : "Open in CodePen"}
+            </button>
+            <button
+              type="button"
+              className="gw-code-panel__action"
+              onClick={handleCopyAscii}
+              title="Copy the rendered ASCII art to the clipboard"
+            >
+              {copyState === "copied" ? "Copied" : copyState === "error" ? "Copy failed" : "Copy ASCII"}
             </button>
             <button
               type="button"

--- a/website/src/components/WordArtWorkbench/WordArtWorkbench.tsx
+++ b/website/src/components/WordArtWorkbench/WordArtWorkbench.tsx
@@ -313,7 +313,6 @@ export function WordArtWorkbench() {
   const [familyInput, setFamilyInput] = useState(() => qs("font"));
   const [weight, setWeight] = useState(() => qs("weight"));
   const [italic, setItalic] = useState(() => qs("italic"));
-  const [status, setStatus] = useState("");
 
   const [text, setText] = useState(() => qs("text"));
   const [textCase, setTextCase] = useState<"as-typed" | "upper" | "lower" | "title">(() => qs("textCase"));
@@ -535,18 +534,15 @@ export function WordArtWorkbench() {
   // preset tiles' static single-letter renders.
   useEffect(() => {
     let alive = true;
-    setStatus(`loading ${entry.family}…`);
     loadGoogleFont(entry, weight, italic ? "italic" : "normal")
       .then((f) => {
         if (!alive) return;
         setFont(f);
         setPreviewFont((prev) => prev ?? f);
-        setStatus(`${entry.family} ${weight}${italic ? " italic" : ""}`);
       })
       .catch((e) => {
         if (!alive) return;
         console.error(`WordArt: failed to load ${entry.family} ${weight}${italic ? " italic" : ""}`, e);
-        setStatus(`couldn't load ${entry.family}: ${e instanceof Error ? e.message : e}`);
       });
     return () => {
       alive = false;
@@ -1047,7 +1043,6 @@ export function WordArtWorkbench() {
             lightColor={lightColor}
             ambient={ambient}
             spin={spin}
-            status={status}
             effectDefinition={effectDefinition}
             effectParams={effectState.params}
             effectBlend={effectState.blend}
@@ -1081,6 +1076,31 @@ export function WordArtWorkbench() {
               title={codeOpen ? "Close export code window" : "Open export code window"}
             >
               Export
+            </button>
+          </div>
+          {/* Viewing-angle shortcuts over the existing `spin`/`turn`/`tilt`
+              URL state (no new rotation machinery) — sits next to
+              `.wa-export-bar` in the same bottom overlay row, where
+              `.wa-stage-foot`'s polygon-count/status readout used to render.
+              "Still · front face" is both a state (spin off, angle reset) and
+              a one-shot reset, so its `is-active` reflects the exact resting
+              angle rather than treating the pair as a plain toggle. */}
+          <div className="wa-view-bar">
+            <button
+              type="button"
+              className={`gw-code-panel__action${!spin && turn === 0 && tilt === 0 ? " is-active" : ""}`}
+              onClick={() => { setSpin(false); setTurn(0); setTilt(0); }}
+              title="Stop auto-rotate and reset to a flat, front-facing view"
+            >
+              Still · front face
+            </button>
+            <button
+              type="button"
+              className={`gw-code-panel__action${spin ? " is-active" : ""}`}
+              onClick={() => setSpin(true)}
+              title="Auto-rotate the mesh"
+            >
+              Auto rotate
             </button>
           </div>
           {(codeOpen || mobilePanel === "export") && (
@@ -1239,7 +1259,6 @@ interface StageProps {
   lightColor: string;
   ambient: number;
   spin: boolean;
-  status: string;
   effectDefinition: GalleryEffectDefinition | null;
   effectParams: Record<string, GalleryEffectParamValue>;
   effectBlend: GalleryEffectBlend;
@@ -1283,7 +1302,7 @@ function DensityFit({ density }: { density: number }) {
   return null;
 }
 
-function Stage({ polygons, scaleXFrac, scaleYFrac, zoomScale, setZoomScale, turn, setTurn, tilt, setTilt, density, renderMode, charMode, hiddenLines, perspective, lightDir, lightIntensity, lightColor, ambient, spin, status, effectDefinition, effectParams, effectBlend, effectPaused, effectTimeScale, snapshotRef }: StageProps) {
+function Stage({ polygons, scaleXFrac, scaleYFrac, zoomScale, setZoomScale, turn, setTurn, tilt, setTilt, density, renderMode, charMode, hiddenLines, perspective, lightDir, lightIntensity, lightColor, ambient, spin, effectDefinition, effectParams, effectBlend, effectPaused, effectTimeScale, snapshotRef }: StageProps) {
   const stageRef = useRef<HTMLDivElement>(null);
   const [stage, setStage] = useState({ w: 900, h: 600 });
   const draggingRef = useRef(false);
@@ -1388,9 +1407,6 @@ function Stage({ polygons, scaleXFrac, scaleYFrac, zoomScale, setZoomScale, turn
           )}
         </GlyphScene>
       </Cam>
-      <div className="wa-stage-foot">
-        {polygons.length.toLocaleString()} polygons{status ? ` · ${status}` : ""}
-      </div>
     </div>
   );
 }

--- a/website/src/components/WordArtWorkbench/WordArtWorkbench.tsx
+++ b/website/src/components/WordArtWorkbench/WordArtWorkbench.tsx
@@ -1110,6 +1110,8 @@ export function WordArtWorkbench() {
               onCodepen={handleExportCodepenDynamic}
               exporting={exporting}
               onClose={closeCodePanel}
+              onCopyAscii={handleCopyAscii}
+              copyAsciiState={copyState}
             />
           )}
         </main>

--- a/website/src/components/WordArtWorkbench/wordart.css
+++ b/website/src/components/WordArtWorkbench/wordart.css
@@ -148,17 +148,24 @@ textarea.wa-input { resize: vertical; line-height: 1.4; height: auto; padding: 0
   inset: 0;
   background: radial-gradient(circle at 50% 38%, #10141c 0%, #07090d 72%);
 }
-.wa-stage-foot {
+/* Viewing-angle shortcuts ("Still · front face" / "Auto rotate") over the
+   `spin`/`turn`/`tilt` URL state — sits centered in the same bottom overlay
+   row as `.wa-export-bar` (left-aligned), so visually to its right. Replaces
+   the old `.wa-stage-foot` polygon-count/status readout. */
+.wa-view-bar {
   position: absolute;
   bottom: var(--overlay-bottom, 12px);
   left: 50%;
   transform: translateX(-50%);
-  font-size: 11px;
-  color: rgba(255, 232, 184, 0.55);
-  pointer-events: none;
-  background: rgba(6, 8, 13, 0.75);
-  padding: 3px 10px;
-  border: 1px solid rgba(255, 232, 184, 0.14);
+  z-index: 15;
+  display: flex;
+  gap: 6px;
+}
+.wa-view-bar .gw-code-panel__action { background: #0d1018; }
+.wa-view-bar .gw-code-panel__action.is-active {
+  color: #03050a;
+  background: rgba(56, 189, 248, 0.85);
+  border-color: rgba(56, 189, 248, 0.85);
 }
 .wa-stage .glyph-output { color: rgba(255, 232, 184, 0.92); margin: 0; }
 
@@ -201,8 +208,11 @@ textarea.wa-input { resize: vertical; line-height: 1.4; height: auto; padding: 0
 }
 
 @media (max-width: 760px) {
-  /* The bar duplicates the mobile tab bar's "Export" tab — hide it and rely
-     on that tab (same drawer, opened via `mobilePanel === "export"`). */
+  /* "Open in CodePen" and "Export" duplicate the mobile tab bar's "Export"
+     tab, so hide the whole bar and rely on that tab (same drawer, opened via
+     `mobilePanel === "export"`). "Copy ASCII" has no such duplicate on its
+     own — `WordArtCodePanel` mounts its own "Copy ASCII" action (next to its
+     code-snippet "Copy") specifically so this hide doesn't strand it. */
   .dn-root--wordart .wa-export-bar { display: none; }
 
   /* Export becomes a full bottom-drawer reachable via the Export tab —
@@ -222,12 +232,8 @@ textarea.wa-input { resize: vertical; line-height: 1.4; height: auto; padding: 0
 
 /* glyphcss render chain must fill the stage so autoSize gets the full grid.
    The camera + scene host are plain divs that otherwise collapse to content
-   height. `:not(.wa-stage-foot)` excludes the status pill below — it's ALSO
-   a direct child div of `.wa-stage`, and without the exclusion this stretched
-   it to 100% × 100% of the stage (full width/height, its 1px border then
-   reading as a giant outline over most of the viewport, right up against the
-   left rail's edge). */
-.wa-stage > div:not(.wa-stage-foot),
+   height. */
+.wa-stage > div,
 .wa-stage .glyph-host,
 .wa-stage .glyph-scene {
   width: 100%;
@@ -530,7 +536,7 @@ textarea.wa-input { resize: vertical; line-height: 1.4; height: auto; padding: 0
   }
   .dn-root--wordart .wa-presets.is-mobile-open { display: flex; }
 
-  .wa-stage-foot { bottom: calc(var(--overlay-bottom, 12px) + var(--mobile-tabs-height, 52px) + 8px); }
+  .wa-view-bar { bottom: calc(var(--overlay-bottom, 12px) + var(--mobile-tabs-height, 52px) + 8px); }
 }
 
 /* ── Right Dock: run to the bottom of the body like the left rail ──────────

--- a/website/src/components/WordArtWorkbench/wordart.css
+++ b/website/src/components/WordArtWorkbench/wordart.css
@@ -162,10 +162,16 @@ textarea.wa-input { resize: vertical; line-height: 1.4; height: auto; padding: 0
   gap: 6px;
 }
 .wa-view-bar .gw-code-panel__action { background: #0d1018; }
+/* Active state matches `.gx-toggle-btn.is-active` (the segmented toggles used
+   for bsc/adv and layer 1|2|3), NOT the export bar's filled treatment: a 20%
+   cyan tint with cyan text and a thin inset ring, rather than an 85% fill with
+   inverted dark text. These sit inline beside the stage, so a solid fill reads
+   as a foreign widget next to every other control on the page. */
 .wa-view-bar .gw-code-panel__action.is-active {
-  color: #03050a;
-  background: rgba(56, 189, 248, 0.85);
-  border-color: rgba(56, 189, 248, 0.85);
+  color: rgba(56, 189, 248, 1);
+  background: rgba(56, 189, 248, 0.2);
+  border-color: transparent;
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.85);
 }
 .wa-stage .glyph-output { color: rgba(255, 232, 184, 0.92); margin: 0; }
 

--- a/website/src/components/WordArtWorkbench/wordart.css
+++ b/website/src/components/WordArtWorkbench/wordart.css
@@ -161,16 +161,22 @@ textarea.wa-input { resize: vertical; line-height: 1.4; height: auto; padding: 0
   display: flex;
   gap: 6px;
 }
-.wa-view-bar .gw-code-panel__action { background: #0d1018; }
+.wa-view-bar .gw-code-panel__action { background-color: #0d1018; }
 /* Active state matches `.gx-toggle-btn.is-active` (the segmented toggles used
    for bsc/adv and layer 1|2|3), NOT the export bar's filled treatment: a 20%
    cyan tint with cyan text and a thin inset ring, rather than an 85% fill with
    inverted dark text. These sit inline beside the stage, so a solid fill reads
-   as a foreign widget next to every other control on the page. */
+   as a foreign widget next to every other control on the page. Since this is
+   deliberately the segmented-toggle ring look (excluded from the corner-tick
+   treatment for the same shared-edge reason `.gx-toggle-btn` is, even though
+   this particular button isn't itself segmented), `--gx-bracket` is cleared to
+   `transparent` here so the ring reads on its own instead of fighting a
+   bracket border-color already forced transparent below. */
 .wa-view-bar .gw-code-panel__action.is-active {
   color: rgba(56, 189, 248, 1);
-  background: rgba(56, 189, 248, 0.2);
+  background-color: rgba(56, 189, 248, 0.2);
   border-color: transparent;
+  --gx-bracket: transparent;
   box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.85);
 }
 .wa-stage .glyph-output { color: rgba(255, 232, 184, 0.92); margin: 0; }
@@ -195,12 +201,13 @@ textarea.wa-input { resize: vertical; line-height: 1.4; height: auto; padding: 0
   gap: 6px;
 }
 .wa-export-bar .gw-code-panel__action {
-  background: #0d1018;
+  background-color: #0d1018;
 }
 .wa-export-bar .gw-code-panel__action.is-active {
   color: #03050a;
-  background: rgba(56, 189, 248, 0.85);
+  background-color: rgba(56, 189, 248, 0.85);
   border-color: rgba(56, 189, 248, 0.85);
+  --gx-bracket: rgba(56, 189, 248, 0.85);
 }
 
 /* Compound with `.gw-code-panel` (0,2,0) rather than `.wa-code-panel` alone
@@ -267,8 +274,10 @@ textarea.wa-input { resize: vertical; line-height: 1.4; height: auto; padding: 0
   height: 24px;
   min-width: 0;
   padding: 0;
-  background: #080a0e;
-  border: 1px solid rgba(255, 232, 184, 0.22);
+  background-color: #080a0e;
+  border-block: 0;
+  border-inline: 1px solid rgba(255, 232, 184, 0.22);
+  --gx-bracket: rgba(255, 232, 184, 0.22);
   color: rgba(255, 232, 184, 0.65);
   border-radius: 0;
   cursor: pointer;
@@ -276,10 +285,11 @@ textarea.wa-input { resize: vertical; line-height: 1.4; height: auto; padding: 0
   font-size: 12px;
   font-weight: 600;
 }
-.wa-seg button:hover { border-color: rgba(56, 189, 248, 0.5); }
+.wa-seg button:hover { border-color: rgba(56, 189, 248, 0.5); --gx-bracket: rgba(56, 189, 248, 0.5); }
 .wa-seg button.is-on {
-  background: rgba(56, 189, 248, 0.18);
+  background-color: rgba(56, 189, 248, 0.18);
   border-color: rgba(56, 189, 248, 0.85);
+  --gx-bracket: rgba(56, 189, 248, 0.85);
   color: #ecfeff;
 }
 
@@ -288,8 +298,10 @@ textarea.wa-input { resize: vertical; line-height: 1.4; height: auto; padding: 0
   width: 100%;
   height: 24px;
   padding: 0 8px;
-  background: #080a0e;
-  border: 1px solid rgba(255, 232, 184, 0.22);
+  background-color: #080a0e;
+  border-block: 0;
+  border-inline: 1px solid rgba(255, 232, 184, 0.22);
+  --gx-bracket: rgba(255, 232, 184, 0.22);
   color: rgba(255, 232, 184, 0.75);
   border-radius: 0;
   cursor: pointer;
@@ -297,7 +309,7 @@ textarea.wa-input { resize: vertical; line-height: 1.4; height: auto; padding: 0
   font-size: 12px;
   font-weight: 600;
 }
-.wa-imgbtn:hover { border-color: rgba(56, 189, 248, 0.6); color: #ecfeff; }
+.wa-imgbtn:hover { border-color: rgba(56, 189, 248, 0.6); color: #ecfeff; --gx-bracket: rgba(56, 189, 248, 0.6); }
 
 .wa-texrow { padding-top: 2px; }
 .wa-texgrid { display: grid; grid-template-columns: repeat(8, 1fr); gap: 3px; }
@@ -373,16 +385,22 @@ textarea.wa-input { resize: vertical; line-height: 1.4; height: auto; padding: 0
   display: flex;
   flex-direction: column;
   padding: 0;
-  border: 1px solid rgba(255, 232, 184, 0.18);
-  background: #04060b;
+  border-block: 0;
+  border-inline: 1px solid rgba(255, 232, 184, 0.18);
+  --gx-bracket: rgba(255, 232, 184, 0.18);
+  background-color: #04060b;
   color: rgba(255, 232, 184, 0.7);
   cursor: pointer;
   overflow: hidden;
   font: inherit;
   transition: border-color 0.12s ease, transform 0.12s ease;
 }
-.wa-tile:hover { border-color: rgba(56, 189, 248, 0.9); transform: translateY(-2px); }
-.wa-tile.is-active { border-color: #38bdf8; box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.5); }
+.wa-tile:hover { border-color: rgba(56, 189, 248, 0.9); transform: translateY(-2px); --gx-bracket: rgba(56, 189, 248, 0.9); }
+.wa-tile.is-active {
+  border-color: #38bdf8;
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.5);
+  --gx-bracket: #38bdf8;
+}
 /* Each tile's preview is a static glyphcss render of a single letter styled
    with that preset (see `renderPresetTile` — `compileScene`, no rAF, no live
    scene), not a CSS gradient swatch. `.glyph-output` is `display:inline-block`

--- a/website/src/components/WordArtWorkbench/wordartUrlState.test.ts
+++ b/website/src/components/WordArtWorkbench/wordartUrlState.test.ts
@@ -1,6 +1,26 @@
+// @vitest-environment happy-dom
+//
+// happy-dom (rather than the file-default `node` environment) is needed for
+// the legacy-link regression block below, which exercises the REAL
+// entry-point functions (`readInitialWordArtState`/
+// `wordArtEffectStateFromUrlState`) through an actual `window.location` —
+// same reasoning as synthUrlState.e2e.test.ts. Every other test in this
+// file is a pure `wordArtCodec` call with no `window` dependency, so the
+// environment switch doesn't change their behavior.
 import { describe, expect, it } from "vitest";
-import { WORD_ART_DEFAULTS, wordArtCodec, type WordArtUrlState } from "./wordartUrlState";
-import { encodeEffectParamsPacked } from "../../lib/urlState";
+import {
+  WORD_ART_DEFAULTS,
+  wordArtCodec,
+  readInitialWordArtState,
+  wordArtEffectStateFromUrlState,
+  type WordArtUrlState,
+} from "./wordartUrlState";
+import {
+  createUrlCodec,
+  decodeEffectParamsPacked,
+  encodeEffectParamsPacked,
+  encodeEffectParamsPackedLegacy,
+} from "../../lib/urlState";
 import { galleryEffectDefaultParams, galleryEffectDefinition } from "../GalleryWorkbench/effects";
 
 // The representative state from the task's own measurement: text, profile,
@@ -36,7 +56,7 @@ describe("wordArtCodec", () => {
   });
 
   it("omits all fields equal to default", () => {
-    expect(wordArtCodec.encode(WORD_ART_DEFAULTS)).toBe("p1");
+    expect(wordArtCodec.encode(WORD_ART_DEFAULTS)).toBe("p2");
   });
 
   it("round-trips the representative state exactly", () => {
@@ -84,5 +104,102 @@ describe("wordArtCodec", () => {
     const packed = wordArtCodec.encode(state);
     const roundTripped = wordArtCodec.encode({ ...WORD_ART_DEFAULTS, ...wordArtCodec.decode(packed) });
     expect(roundTripped).toBe(packed);
+  });
+});
+
+// ── Compact codec rewrite: WORD_ART_SCHEMA_VERSION 1 -> 2 (website/src/lib/
+//    urlState.ts's run/list token grammar, same shared change as /synth's
+//    v4 -> v5 and gallery's fx v1 -> v2) ────────────────────────────────────
+// Every other field is unchanged; only the nested `effectParams` field's
+// wire format changed, so a "1"-tagged `?w=` link's `effectParams` must
+// decode through the LEGACY pair (`decodeEffectParamsPackedLegacy`) even
+// though its outer field list is identical — see
+// `wordArtEffectStateFromUrlState`'s `raw[1] === "1"` dispatch.
+describe("wordArtCodec — v1 legacy decode (compact codec rewrite)", () => {
+  it("a genuinely v1-tagged link decodes identically to the equivalent v2 link", () => {
+    // Same representative state, but the OUTER codec is forced to encode at
+    // version "1" the way the pre-bump write path once did, and the nested
+    // `effectParams` is packed with the legacy escape grammar.
+    const state = representativeState();
+    const legacyCodec = createUrlCodec<WordArtUrlState>("1", wordArtCodec.fields);
+    const definition = galleryEffectDefinition("matrix-rain")!;
+    const defaults = galleryEffectDefaultParams(definition);
+    const overrides = decodeEffectParamsPacked(definition.parameterSchema, state.effectParams);
+    const legacyEffectParams = encodeEffectParamsPackedLegacy(definition.parameterSchema, defaults, overrides);
+    const legacyPacked = legacyCodec.encode({ ...state, effectParams: legacyEffectParams });
+    expect(legacyPacked[1]).toBe("1");
+
+    window.history.replaceState(null, "", `/wordart?w=${encodeURIComponent(legacyPacked)}`);
+    const decodedState = readInitialWordArtState();
+    const decodedEffect = wordArtEffectStateFromUrlState(decodedState);
+
+    const currentPacked = wordArtCodec.encode(state);
+    window.history.replaceState(null, "", `/wordart?w=${encodeURIComponent(currentPacked)}`);
+    const currentState = readInitialWordArtState();
+    const currentEffect = wordArtEffectStateFromUrlState(currentState);
+
+    expect(decodedState).toEqual(currentState);
+    expect(decodedEffect).toEqual(currentEffect);
+  });
+
+  // Captured from THIS repo's code BEFORE the v2 compact-codec change landed
+  // (a real `wordArtCodec.encode(representativeState())` output on the
+  // then-current v1 codec, not hand-built) — the strongest available proof
+  // that an already-shared /wordart link keeps decoding to exactly the
+  // state it always did.
+  const REAL_V1_LINK = "p1p0d1kk15bneK0le00b0le00j16L269D1ph1c1r1V3jagR17.17.GLYPH0151l622t7219822g928ia1b015c9c7ao5y";
+
+  it("decodes the real captured v1 link to exactly its pre-change state", () => {
+    expect(REAL_V1_LINK[1]).toBe("1");
+    window.history.replaceState(null, "", `/wordart?w=${encodeURIComponent(REAL_V1_LINK)}`);
+    const decoded = readInitialWordArtState();
+    const expected = representativeState();
+    expect(decoded).toEqual(expected);
+    const effectState = wordArtEffectStateFromUrlState(decoded);
+    expect(effectState.effectId).toBe("matrix-rain");
+    expect(effectState.params.glyphs).toBe("GLYPH01");
+    expect(effectState.params.speedMin).toBeCloseTo(5.25, 3);
+    expect(effectState.params.speedMax).toBeCloseTo(25.25, 3);
+    expect(effectState.params.trail).toBeCloseTo(45, 3);
+    expect(effectState.params.density).toBeCloseTo(0.88, 3);
+    expect(effectState.params.seed).toBeCloseTo(306, 3);
+    expect(effectState.params.colorMode).toBe("monochrome");
+    expect(effectState.params.color).toBe("#00d149");
+    expect(effectState.params.headColor).toBe("#baffd6");
+  });
+
+  it("shows the real win on a richer applied effect (field-synth, a shipped preset's full override set)", async () => {
+    // matrix-rain's small schema (above) is a worst case for these levers —
+    // field-synth's 208-key schema and its typically-repeated per-voice
+    // values is the realistic case they're aimed at (a user picking a
+    // richer effect on /wordart, not just adjusting text controls).
+    const { GlyphCssGraphicsMengerPreset, GlyphFieldSynthEffect: fieldSynthEffect, defaultGlyphEffectParams: defaultParams } = await import("@glyphcss/effects");
+    const defaults = defaultParams(fieldSynthEffect) as Record<string, unknown>;
+    const overrides = GlyphCssGraphicsMengerPreset.params as Record<string, unknown>;
+    const legacyEffectParams = encodeEffectParamsPackedLegacy(fieldSynthEffect.parameterSchema, defaults, overrides);
+    const newEffectParams = encodeEffectParamsPacked(fieldSynthEffect.parameterSchema, defaults, overrides);
+    const state = { ...WORD_ART_DEFAULTS, text: "Glyph\nCSS", effectId: "field-synth", effectBlend: "over" as const, effectTimeScale: 1 };
+    const legacyCodec = createUrlCodec<WordArtUrlState>("1", wordArtCodec.fields);
+    const legacyPacked = legacyCodec.encode({ ...state, effectParams: legacyEffectParams });
+    const newPacked = wordArtCodec.encode({ ...state, effectParams: newEffectParams });
+    expect(newPacked.length).toBeLessThan(legacyPacked.length);
+    // eslint-disable-next-line no-console
+    console.log(`wordart ?w= (field-synth, Menger cssGraphics overrides): v1 ${legacyPacked.length} chars -> v2 ${newPacked.length} chars`);
+  });
+
+  it("re-encodes the representative state at least as short as the captured v1 length", () => {
+    // matrix-rain's own parameterSchema is small (well under the compact
+    // codec's 58-key direct-index range) and this representative state's 9
+    // effect-param overrides share no repeated values, so neither the
+    // cheaper index escape nor the run/list tokens have anything to bite on
+    // here — an exact tie is the CORRECT outcome for this specific patch,
+    // not a regression. The real win shows up on a payload with either a
+    // large schema (field-synth, 208 keys — see synthUrlState.test.ts) or
+    // genuinely repeated override values.
+    const packed = wordArtCodec.encode(representativeState());
+    expect(packed[1]).toBe("2");
+    expect(packed.length).toBeLessThanOrEqual(REAL_V1_LINK.length);
+    // eslint-disable-next-line no-console
+    console.log(`wordart representative: v1 ${REAL_V1_LINK.length} chars -> v2 ${packed.length} chars`);
   });
 });

--- a/website/src/components/WordArtWorkbench/wordartUrlState.ts
+++ b/website/src/components/WordArtWorkbench/wordartUrlState.ts
@@ -6,6 +6,7 @@
 import {
   createUrlCodec,
   decodeEffectParamsPacked,
+  decodeEffectParamsPackedLegacy,
   encodeEffectParamsPacked,
   readUrlParam,
   scheduleCompactedUrlWrite,
@@ -215,25 +216,43 @@ const wordArtFields: readonly UrlField<WordArtUrlState>[] = [
   { key: "effectParams", token: "R", type: { kind: "string" }, default: "" },
 ];
 
-const WORD_ART_SCHEMA_VERSION = "1";
+// Bumped 1 -> 2 for the shared codec's compact-index/run/list rewrite of
+// `encodeEffectParamsPacked`/`decodeEffectParamsPacked` (website/src/lib/
+// urlState.ts) — every OTHER field here is unchanged; only `effectParams`'s
+// internal wire format changed, so a "1"-tagged link's nested payload must
+// decode through the LEGACY pair (`decodeEffectParamsPackedLegacy`) — see
+// `readInitialWordArtState`/`wordArtEffectStateFromUrlState` below.
+const WORD_ART_SCHEMA_VERSION = "2";
 export const wordArtCodec = createUrlCodec<WordArtUrlState>(WORD_ART_SCHEMA_VERSION, wordArtFields);
+const wordArtCodecLegacyV1 = createUrlCodec<WordArtUrlState>("1", wordArtFields);
 
 const WORD_ART_PARAM = "w";
+
+function decodeWordArtOuter(raw: string | null | undefined): Partial<WordArtUrlState> {
+  if (raw && raw[1] === "1") return wordArtCodecLegacyV1.decode(raw);
+  return wordArtCodec.decode(raw);
+}
 
 /** Read the initial state from the URL (defaults for anything absent/garbage
  *  — `decode` never throws, see urlState.ts). */
 export function readInitialWordArtState(): WordArtUrlState {
-  return { ...WORD_ART_DEFAULTS, ...wordArtCodec.decode(readUrlParam(WORD_ART_PARAM)) };
+  return { ...WORD_ART_DEFAULTS, ...decodeWordArtOuter(readUrlParam(WORD_ART_PARAM)) };
 }
 
 /** Restore the Effects folder's selection (mirrors the gallery's `fx` shape,
- *  folded into this page's single packed param instead of a second key). */
+ *  folded into this page's single packed param instead of a second key).
+ *  Re-reads the raw `?w=` param (cheap, same page load `readInitialWordArtState`
+ *  already read it on) purely to resolve which `effectParams` wire format a
+ *  "1"-tagged link used — everything else about `state` is already correctly
+ *  decoded by the OUTER dispatch above. */
 export function wordArtEffectStateFromUrlState(state: WordArtUrlState): GalleryEffectState {
   if (!state.effectId) return DEFAULT_GALLERY_EFFECT_STATE;
   const definition = galleryEffectDefinition(state.effectId as GlyphEffectId);
   if (!definition) return DEFAULT_GALLERY_EFFECT_STATE;
   const defaults = galleryEffectDefaultParams(definition);
-  const overrides = decodeEffectParamsPacked(definition.parameterSchema, state.effectParams) as Record<string, GalleryEffectParamValue>;
+  const raw = readUrlParam(WORD_ART_PARAM);
+  const decodeParams = raw && raw[1] === "1" ? decodeEffectParamsPackedLegacy : decodeEffectParamsPacked;
+  const overrides = decodeParams(definition.parameterSchema, state.effectParams) as Record<string, GalleryEffectParamValue>;
   return {
     effectId: definition.id,
     effectVersion: definition.version,

--- a/website/src/lib/asciiClipboard.test.ts
+++ b/website/src/lib/asciiClipboard.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { extractAsciiFromPre, trimTrailingWhitespacePerLine } from "./asciiClipboard";
+
+describe("trimTrailingWhitespacePerLine", () => {
+  it("trims trailing spaces on every line", () => {
+    expect(trimTrailingWhitespacePerLine("abc   \ndef  \n")).toBe("abc\ndef\n");
+  });
+
+  it("preserves leading whitespace (the art's own left offset)", () => {
+    expect(trimTrailingWhitespacePerLine("   abc   \n  def")).toBe("   abc\n  def");
+  });
+
+  it("leaves lines with no trailing whitespace untouched", () => {
+    expect(trimTrailingWhitespacePerLine("abc\ndef")).toBe("abc\ndef");
+  });
+
+  it("trims trailing tabs as well as spaces", () => {
+    expect(trimTrailingWhitespacePerLine("abc\t\t\ndef")).toBe("abc\ndef");
+  });
+});
+
+describe("extractAsciiFromPre", () => {
+  it("returns null for a null pre", () => {
+    expect(extractAsciiFromPre(null)).toBeNull();
+  });
+
+  it("returns null for an empty/whitespace-only pre", () => {
+    const pre = document.createElement("pre");
+    pre.textContent = "   \n   \n";
+    expect(extractAsciiFromPre(pre)).toBeNull();
+  });
+
+  it("reads textContent, not innerHTML — strips span markup, keeps text", () => {
+    const pre = document.createElement("pre");
+    pre.innerHTML = '<span style="color:red">##</span>  \n<span>..</span>  ';
+    const out = extractAsciiFromPre(pre);
+    expect(out).not.toBeNull();
+    expect(out).not.toContain("<span");
+    expect(out).not.toContain("</span>");
+    expect(out).toBe("##\n..");
+  });
+
+  it("trims trailing whitespace per line from a grid-padded render", () => {
+    const pre = document.createElement("pre");
+    pre.textContent = "  /\\  \n /  \\ \n/____\\";
+    expect(extractAsciiFromPre(pre)).toBe("  /\\\n /  \\\n/____\\");
+  });
+});

--- a/website/src/lib/asciiClipboard.ts
+++ b/website/src/lib/asciiClipboard.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared "copy the rendered ASCII" support for /synth and /wordart. The stage
+ * `<pre class="glyph-output">` carries color `<span>`s in colored-output mode,
+ * so the button must read `textContent` (never `innerHTML`) to get plain text.
+ *
+ * Rows are space-padded to the grid width — trimming each line's TRAILING
+ * whitespace makes a pasted copy usable; LEADING whitespace is the art's own
+ * left offset and must survive untouched.
+ */
+
+/** Trim trailing whitespace from every line, leaving leading whitespace intact. */
+export function trimTrailingWhitespacePerLine(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+$/, ""))
+    .join("\n");
+}
+
+/** Extract the copy-ready ASCII string from a stage `<pre>`, or `null` if there's nothing to copy. */
+export function extractAsciiFromPre(pre: HTMLElement | null): string | null {
+  const raw = pre?.textContent ?? "";
+  if (!raw.trim()) return null;
+  return trimTrailingWhitespacePerLine(raw);
+}

--- a/website/src/lib/urlState.test.ts
+++ b/website/src/lib/urlState.test.ts
@@ -232,18 +232,20 @@ describe("encodeEffectParamsPacked / decodeEffectParamsPacked", () => {
   });
 });
 
-// ── Multi-char index escape (schemas past 61 keys) ──────────────────────────
-// A single base62 char only reaches index 61; a schema past that (e.g.
-// fieldSynthSchema, well past 120 keys) needs the `INDEX_ESCAPE`-prefixed
-// 2-char form. Built here as a synthetic 70-key schema so the test doesn't
-// depend on @glyphcss/effects' actual key count/order.
+// ── Multi-char index escape (schemas past 58 direct-range keys) ────────────
+// The compact codec's direct range is indices 0..58 (one BASE62 char); index
+// 59+ escapes to a 2-char form using BASE62's own top 3 chars ('X'/'Y'/'Z')
+// as the hi digit — see urlState.ts's "Compact effect-params codec" section
+// doc for why the cutoff sits at 58, not 61. Built here as a synthetic
+// 70-key schema so the test doesn't depend on @glyphcss/effects' actual key
+// count/order.
 function bigSchema(size: number): EffectParamSchemaLike {
   const schema: Record<string, EffectParamSpecLike> = {};
   for (let i = 0; i < size; i++) schema[`k${i}`] = { kind: "number", default: 0, step: 1 };
   return schema;
 }
 
-describe("encodeEffectParamsPacked index escape (indices >= 62)", () => {
+describe("encodeEffectParamsPacked index escape (indices >= 59)", () => {
   it("round-trips a param whose schema index is past the single-char cap", () => {
     const schema = bigSchema(70);
     const defaults = Object.fromEntries(Object.keys(schema).map((k) => [k, 0]));
@@ -252,10 +254,10 @@ describe("encodeEffectParamsPacked index escape (indices >= 62)", () => {
     expect(decodeEffectParamsPacked(schema, packed)).toEqual(overrides);
   });
 
-  it("round-trips a mix of sub-62 and >=62 indices in one packed string", () => {
+  it("round-trips a mix of sub-59 and >=59 indices in one packed string", () => {
     const schema = bigSchema(70);
     const defaults = Object.fromEntries(Object.keys(schema).map((k) => [k, 0]));
-    const overrides = { k3: 1, k61: 2, k62: 3, k68: 4 };
+    const overrides = { k3: 1, k58: 2, k59: 3, k68: 4 };
     const packed = encodeEffectParamsPacked(schema, defaults, overrides);
     expect(decodeEffectParamsPacked(schema, packed)).toEqual(overrides);
   });
@@ -269,12 +271,296 @@ describe("encodeEffectParamsPacked index escape (indices >= 62)", () => {
     }
   });
 
-  it("a pre-escape (index < 62 only) packed string decodes identically before and after this format extension", () => {
+  it("exercises the exact direct/escape boundary (58 direct, 59 escaped)", () => {
     const schema = bigSchema(70);
     const defaults = Object.fromEntries(Object.keys(schema).map((k) => [k, 0]));
-    const overrides = { k0: 5, k10: -3, k61: 99 };
+    const overrides = { k0: 5, k10: -3, k58: 99, k59: 100 };
     const packed = encodeEffectParamsPacked(schema, defaults, overrides);
-    expect(packed).not.toContain("_");
     expect(decodeEffectParamsPacked(schema, packed)).toEqual(overrides);
   });
+
+  it("throws at ENCODE time (loudly, not a silent wraparound) for a schema index past the compact codec's representable range", () => {
+    // 59 direct + 3 escape chars x 62 = 245 representable indices (0..244).
+    // A schema past that needs another version bump, not a corrupted link —
+    // see `encodeCompactIndex`'s doc.
+    const schema = bigSchema(250);
+    const defaults = Object.fromEntries(Object.keys(schema).map((k) => [k, 0]));
+    expect(() => encodeEffectParamsPacked(schema, defaults, { k249: 1 })).toThrow();
+  });
 });
+
+// ── Run tokens (RUN_MARKER "_"): identical values at CONSECUTIVE indices ───
+describe("encodeEffectParamsPacked run tokens", () => {
+  it("collapses a consecutive-index run sharing one value into a single run token", () => {
+    const schema = bigSchema(20);
+    const defaults = Object.fromEntries(Object.keys(schema).map((k) => [k, 0]));
+    const overrides = { k2: 7, k3: 7, k4: 7, k5: 7 };
+    const packed = encodeEffectParamsPacked(schema, defaults, overrides);
+    expect(packed).toContain("_");
+    // 4 individual tokens would cost 4 * (1 index char + up to 2 value
+    // chars) = up to 12 chars; the run token is markedly shorter.
+    expect(packed.length).toBeLessThan(10);
+    expect(decodeEffectParamsPacked(schema, packed)).toEqual(overrides);
+  });
+
+  it("does NOT merge a run across a value change (breaks the run at the differing member)", () => {
+    const schema = bigSchema(20);
+    const defaults = Object.fromEntries(Object.keys(schema).map((k) => [k, 0]));
+    const overrides = { k2: 7, k3: 7, k4: 9, k5: 7 };
+    const packed = encodeEffectParamsPacked(schema, defaults, overrides);
+    expect(decodeEffectParamsPacked(schema, packed)).toEqual(overrides);
+  });
+
+  it("does NOT merge two keys of a DIFFERENT kind/step even at consecutive indices with a coincidentally-equal encoded value", () => {
+    // The exact bug class caught during design: a schema where consecutive
+    // keys have different `step`s can encode the SAME raw digit string for
+    // DIFFERENT real numbers. Grouping by encoded string alone (ignoring
+    // step) would silently swap a decoded value's real magnitude.
+    const schema: EffectParamSchemaLike = {
+      a: { kind: "number", default: 0, step: 0.1 },
+      b: { kind: "number", default: 0, step: 0.05 },
+    };
+    const defaults = { a: 0, b: 0 };
+    // Both round to the same base36 digit string for their own step (units
+    // 20 -> digits "k"), but a's real value (2.0) != b's real value (1.0).
+    const overrides = { a: 2.0, b: 1.0 };
+    const packed = encodeEffectParamsPacked(schema, defaults, overrides);
+    const decoded = decodeEffectParamsPacked(schema, packed);
+    expect(decoded.a).toBeCloseTo(2.0, 5);
+    expect(decoded.b).toBeCloseTo(1.0, 5);
+  });
+
+  it("splits a run longer than the single-char count field's max (61) into multiple run tokens", () => {
+    const schema = bigSchema(80);
+    const defaults = Object.fromEntries(Object.keys(schema).map((k) => [k, 0]));
+    const overrides = Object.fromEntries(Array.from({ length: 70 }, (_, i) => [`k${i}`, 3]));
+    const packed = encodeEffectParamsPacked(schema, defaults, overrides);
+    expect(decodeEffectParamsPacked(schema, packed)).toEqual(overrides);
+  });
+
+  it("never throws on truncated run-token input", () => {
+    const schema = bigSchema(20);
+    const defaults = Object.fromEntries(Object.keys(schema).map((k) => [k, 0]));
+    const full = encodeEffectParamsPacked(schema, defaults, { k2: 7, k3: 7, k4: 7 });
+    for (let i = 1; i < full.length; i++) {
+      expect(() => decodeEffectParamsPacked(schema, full.slice(0, i))).not.toThrow();
+    }
+  });
+});
+
+// ── List tokens (LIST_MARKER "*"): identical values at SCATTERED indices ───
+describe("encodeEffectParamsPacked list tokens", () => {
+  it("collapses a scattered-index group sharing one value into a single list token when it's cheaper", () => {
+    const schema = bigSchema(20);
+    const defaults = Object.fromEntries(Object.keys(schema).map((k) => [k, 0]));
+    // step 1 -> encoded value "1k" is 2 chars; (n-1)*2 - 2 > 0 for n >= 3.
+    const overrides = { k1: 20, k7: 20, k13: 20, k19: 20 };
+    const packed = encodeEffectParamsPacked(schema, defaults, overrides);
+    expect(packed).toContain("*");
+    expect(decodeEffectParamsPacked(schema, packed)).toEqual(overrides);
+  });
+
+  it("does NOT list-group a 2-member/1-char-value pair that would cost MORE as a list (falls back to individual tokens)", () => {
+    const schema = bigSchema(20);
+    const defaults = Object.fromEntries(Object.keys(schema).map((k) => [k, 0]));
+    const overrides = { k1: 3, k7: 3 }; // value "3" is 1 char; (2-1)*1 - 2 < 0
+    const packed = encodeEffectParamsPacked(schema, defaults, overrides);
+    expect(packed).not.toContain("*");
+    expect(decodeEffectParamsPacked(schema, packed)).toEqual(overrides);
+  });
+
+  it("does NOT merge two keys of a DIFFERENT kind/step sharing a coincidentally-equal encoded value into one list", () => {
+    const schema: EffectParamSchemaLike = {
+      a: { kind: "number", default: 0, step: 0.1 },
+      b: { kind: "number", default: 0, step: 0.05 },
+      c: { kind: "number", default: 0, step: 0.1 },
+      d: { kind: "number", default: 0, step: 0.1 },
+    };
+    const defaults = { a: 0, b: 0, c: 0, d: 0 };
+    const overrides = { a: 2.0, b: 1.0, c: 2.0, d: 2.0 }; // a/c/d share step 0.1, b doesn't
+    const packed = encodeEffectParamsPacked(schema, defaults, overrides);
+    const decoded = decodeEffectParamsPacked(schema, packed);
+    expect(decoded).toEqual(overrides);
+  });
+
+  it("never throws on truncated list-token input", () => {
+    const schema = bigSchema(20);
+    const defaults = Object.fromEntries(Object.keys(schema).map((k) => [k, 0]));
+    const full = encodeEffectParamsPacked(schema, defaults, { k1: 20, k7: 20, k13: 20 });
+    for (let i = 1; i < full.length; i++) {
+      expect(() => decodeEffectParamsPacked(schema, full.slice(0, i))).not.toThrow();
+    }
+  });
+});
+
+// ── Adversarial delimiters: RUN_MARKER "_" / LIST_MARKER "*" inside a free
+//    string VALUE, alongside real run/list tokens in the SAME packed string
+//    — proving the length-prefixed string value never gets misread as a
+//    fresh marker, and a real marker never bleeds into adjacent content. ──
+describe("compact codec — adversarial delimiter round-trips", () => {
+  it("a free string value containing literal '_' and '*' round-trips unambiguously, even sitting next to a real run token", () => {
+    const schema: EffectParamSchemaLike = {
+      text: { kind: "string", default: "" },
+      r1: { kind: "number", default: 0, step: 1 },
+      r2: { kind: "number", default: 0, step: 1 },
+      r3: { kind: "number", default: 0, step: 1 },
+    };
+    const defaults = { text: "", r1: 0, r2: 0, r3: 0 };
+    // The string's own content is a plausible-looking (but fake) run/list
+    // token — "_XY5" / "*3..." — that must be consumed as opaque length-
+    // prefixed content, never re-parsed as a marker.
+    const overrides = { text: "a_XY5*3bb_hi*there_", r1: 9, r2: 9, r3: 9 };
+    const packed = encodeEffectParamsPacked(schema, defaults, overrides);
+    expect(packed).toContain("_"); // the REAL run token for r1/r2/r3
+    expect(decodeEffectParamsPacked(schema, packed)).toEqual(overrides);
+  });
+
+  it("a free string value ending in digits round-trips correctly when immediately followed by another token", () => {
+    const schema: EffectParamSchemaLike = {
+      text: { kind: "string", default: "" },
+      n: { kind: "number", default: 0, step: 1 },
+    };
+    const defaults = { text: "", n: 0 };
+    const overrides = { text: "ends-with-9", n: 42 };
+    const packed = encodeEffectParamsPacked(schema, defaults, overrides);
+    expect(decodeEffectParamsPacked(schema, packed)).toEqual(overrides);
+  });
+
+  it("an empty string value round-trips", () => {
+    const schema: EffectParamSchemaLike = { text: { kind: "string", default: "x" } };
+    const packed = encodeEffectParamsPacked(schema, { text: "x" }, { text: "" });
+    expect(decodeEffectParamsPacked(schema, packed)).toEqual({ text: "" });
+  });
+});
+
+// ── Fuzz: hundreds of randomized patches, encode -> decode -> deep-equal ───
+describe("compact codec — round-trip fuzz", () => {
+  const FUZZ_ENUM = ["alpha", "beta", "gamma", "delta"] as const;
+  const fuzzSchema: EffectParamSchemaLike = {
+    time: { kind: "number", default: 0, step: 0.01 },
+    // A 9-member family sharing kind+step, mirroring field-synth's per-voice
+    // layout — the shape run/list tokens are aimed at.
+    ...Object.fromEntries(Array.from({ length: 9 }, (_, i) => [`freq${i + 1}`, { kind: "number", default: 1, step: 0.1 } as EffectParamSpecLike])),
+    ...Object.fromEntries(Array.from({ length: 9 }, (_, i) => [`amp${i + 1}`, { kind: "number", default: 0, step: 0.05 } as EffectParamSpecLike])),
+    ...Object.fromEntries(Array.from({ length: 9 }, (_, i) => [`on${i + 1}`, { kind: "boolean", default: false } as EffectParamSpecLike])),
+    mode: { kind: "string", default: "alpha", values: FUZZ_ENUM },
+    label: { kind: "string", default: "" },
+    tint: { kind: "color", default: "#000000" },
+    // Push well past the direct-index range (>= 59) to exercise the escape.
+    ...Object.fromEntries(Array.from({ length: 60 }, (_, i) => [`pad${i}`, { kind: "number", default: 0, step: 1 } as EffectParamSpecLike])),
+  };
+  const fuzzKeys = Object.keys(fuzzSchema).filter((k) => k !== "time");
+  const fuzzDefaults = Object.fromEntries(Object.entries(fuzzSchema).map(([k, spec]) => [k, spec.default]));
+
+  function randomValueFor(spec: EffectParamSpecLike, rng: () => number): unknown {
+    if (spec.kind === "boolean") return rng() < 0.5;
+    if (spec.kind === "color") return `#${Math.floor(rng() * 0xffffff).toString(16).padStart(6, "0")}`;
+    if (spec.kind === "string" && spec.values) return spec.values[Math.floor(rng() * spec.values.length)];
+    if (spec.kind === "string") {
+      const pool = ["", "x", "hello world", "a_b*c", "unicode 世界 🎉", "  spaced  ", "-1", "0.5"];
+      return pool[Math.floor(rng() * pool.length)];
+    }
+    // number: mix of edge cases and random fractional/negative values.
+    const edgeCases = [0, -1, 1, -999999, 999999, 0.0001, -0.0001];
+    if (rng() < 0.2) return edgeCases[Math.floor(rng() * edgeCases.length)];
+    return Math.round((rng() * 2000 - 1000) / (spec.step ?? 1)) * (spec.step ?? 1);
+  }
+
+  // Deterministic mulberry32 PRNG — reproducible failures, no external dep.
+  function mulberry32(seed: number): () => number {
+    let a = seed;
+    return () => {
+      a |= 0; a = (a + 0x6d2b79f5) | 0;
+      let t = Math.imul(a ^ (a >>> 15), 1 | a);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+
+  it("round-trips 500 randomized patches (partial overrides, mixed kinds)", () => {
+    const rng = mulberry32(20260215);
+    for (let trial = 0; trial < 500; trial++) {
+      const overrideCount = Math.floor(rng() * (fuzzKeys.length + 1));
+      const shuffled = [...fuzzKeys].sort(() => rng() - 0.5);
+      const chosen = shuffled.slice(0, overrideCount);
+      const overrides: Record<string, unknown> = {};
+      for (const key of chosen) overrides[key] = randomValueFor(fuzzSchema[key]!, rng);
+      const packed = encodeEffectParamsPacked(fuzzSchema, fuzzDefaults, overrides);
+      const decoded = decodeEffectParamsPacked(fuzzSchema, packed);
+      for (const key of chosen) {
+        const spec = fuzzSchema[key]!;
+        if (sameSpecValueForTest(spec, overrides[key], fuzzDefaults[key])) {
+          // Genuinely equal to default (possible after step-rounding an
+          // edge-case value) — legitimately omitted, nothing to assert.
+          continue;
+        }
+        if (spec.kind === "number") {
+          expect(decoded[key], `trial ${trial} key ${key}`).toBeCloseTo(quantizeForTest(spec, overrides[key] as number), 5);
+        } else if (spec.kind === "color") {
+          expect(String(decoded[key]).toLowerCase(), `trial ${trial} key ${key}`).toBe(String(overrides[key]).toLowerCase());
+        } else {
+          expect(decoded[key], `trial ${trial} key ${key}`).toBe(overrides[key]);
+        }
+      }
+    }
+  });
+
+  it("round-trips the all-defaults patch to an empty payload", () => {
+    expect(encodeEffectParamsPacked(fuzzSchema, fuzzDefaults, fuzzDefaults)).toBe("");
+  });
+
+  it("round-trips the all-non-default patch (every key touched at once)", () => {
+    const rng = mulberry32(1);
+    const overrides: Record<string, unknown> = {};
+    for (const key of fuzzKeys) {
+      let value = randomValueFor(fuzzSchema[key]!, rng);
+      // Force genuinely non-default for number/boolean/color (string enum
+      // already differs by construction below).
+      while (sameSpecValueForTest(fuzzSchema[key]!, value, fuzzDefaults[key])) value = randomValueFor(fuzzSchema[key]!, rng);
+      overrides[key] = value;
+    }
+    const packed = encodeEffectParamsPacked(fuzzSchema, fuzzDefaults, overrides);
+    const decoded = decodeEffectParamsPacked(fuzzSchema, packed);
+    for (const key of fuzzKeys) {
+      const spec = fuzzSchema[key]!;
+      if (spec.kind === "number") expect(decoded[key], key).toBeCloseTo(quantizeForTest(spec, overrides[key] as number), 5);
+      else if (spec.kind === "color") expect(String(decoded[key]).toLowerCase(), key).toBe(String(overrides[key]).toLowerCase());
+      else expect(decoded[key], key).toBe(overrides[key]);
+    }
+  });
+
+  it("hits every enum value at least once across a scan of all mode values", () => {
+    for (const value of FUZZ_ENUM) {
+      const packed = encodeEffectParamsPacked(fuzzSchema, fuzzDefaults, { mode: value });
+      expect(decodeEffectParamsPacked(fuzzSchema, packed).mode).toBe(value === fuzzDefaults.mode ? undefined : value);
+    }
+  });
+
+  it("never throws across truncation of 20 randomized full patches", () => {
+    const rng = mulberry32(7);
+    for (let trial = 0; trial < 20; trial++) {
+      const overrides: Record<string, unknown> = {};
+      for (const key of fuzzKeys) if (rng() < 0.6) overrides[key] = randomValueFor(fuzzSchema[key]!, rng);
+      const full = encodeEffectParamsPacked(fuzzSchema, fuzzDefaults, overrides);
+      for (let i = 0; i < full.length; i += 3) {
+        expect(() => decodeEffectParamsPacked(fuzzSchema, full.slice(0, i)), `trial ${trial} cut ${i}`).not.toThrow();
+      }
+    }
+  });
+});
+
+function quantizeForTest(spec: EffectParamSpecLike, value: number): number {
+  const step = spec.step && spec.step > 0 ? spec.step : 0.0001;
+  return Math.round(value / step) * step;
+}
+
+function sameSpecValueForTest(spec: EffectParamSpecLike, a: unknown, b: unknown): boolean {
+  if (spec.kind === "number" && typeof a === "number" && typeof b === "number") {
+    const step = spec.step && spec.step > 0 ? spec.step : 0.0001;
+    return Math.round(a / step) === Math.round(b / step);
+  }
+  if (spec.kind === "color" && typeof a === "string" && typeof b === "string") {
+    return a.toLowerCase() === b.toLowerCase();
+  }
+  return a === b;
+}

--- a/website/src/lib/urlState.ts
+++ b/website/src/lib/urlState.ts
@@ -508,13 +508,21 @@ function sameSpecValue(spec: EffectParamSpecLike, a: unknown, b: unknown): boole
   return a === b;
 }
 
-/** Diff `values` against `defaults` and pack the overrides against `schema`,
- *  keyed by each param's position in `Object.keys(schema)` — a single base62
- *  char for indices 0..61, an `INDEX_ESCAPE`-prefixed 2-char form beyond that
- *  (see `encodeTokenIndex`; `fieldSynthSchema` is already past 120 keys, so
- *  this isn't a theoretical case). Returns "" for no overrides. `time`/
- *  `skipKeys` are excluded (animated/derived, not part of a shareable link). */
-export function encodeEffectParamsPacked(
+/** Legacy (pre-compaction) pack: diff `values` against `defaults` and pack
+ *  the overrides against `schema`, keyed by each param's position in
+ *  `Object.keys(schema)` — a single base62 char for indices 0..61, an
+ *  `INDEX_ESCAPE`-prefixed 2-char form beyond that (see `encodeTokenIndex`;
+ *  `fieldSynthSchema` is already past 120 keys, so this isn't a theoretical
+ *  case). Returns "" for no overrides. `time`/`skipKeys` are excluded
+ *  (animated/derived, not part of a shareable link).
+ *
+ *  Kept ONLY for each consumer's own legacy-version decode branch (see
+ *  synthUrlState.ts/wordartUrlState.ts/useEffectRouteSync.ts's own version
+ *  bumps) — every new link is written with `encodeEffectParamsPacked`
+ *  below instead, which packs the identical override set to noticeably
+ *  fewer characters. Never call this for a NEW write; it exists so an
+ *  already-shared old link keeps decoding to the exact state it always did. */
+export function encodeEffectParamsPackedLegacy(
   schema: EffectParamSchemaLike,
   defaults: Record<string, unknown>,
   values: Record<string, unknown>,
@@ -536,9 +544,10 @@ export function encodeEffectParamsPacked(
   return out;
 }
 
-/** Inverse of `encodeEffectParamsPacked`. Never throws: an unknown token or
- *  malformed value stops decoding and returns whatever parsed so far. */
-export function decodeEffectParamsPacked(
+/** Inverse of `encodeEffectParamsPackedLegacy`. Never throws: an unknown
+ *  token or malformed value stops decoding and returns whatever parsed so
+ *  far. Legacy-decode-only — see that function's doc. */
+export function decodeEffectParamsPackedLegacy(
   schema: EffectParamSchemaLike,
   packed: string | undefined,
 ): Record<string, unknown> {
@@ -558,6 +567,313 @@ export function decodeEffectParamsPacked(
       if (!decoded) break;
       out[name] = decoded.value;
       index = decoded.next;
+    }
+  } catch {
+    return out;
+  }
+  return out;
+}
+
+// ── Compact effect-params codec (v2 token grammar) ──────────────────────────
+// Supersedes the legacy pair above for every NEW write. Two independent
+// savings over the legacy format, both measured on a real /synth link (see
+// this repo's history for the numbers):
+//
+// 1. Cheaper index escape. A single BASE62 char still covers values 0..58
+//    directly, but the escape for values beyond that is 2 chars instead of
+//    the legacy `INDEX_ESCAPE`'s 3 (`<hiChar><loChar>` using BASE62's own
+//    top 3 characters — index 59/60/61, i.e. 'X'/'Y'/'Z' — as the hi digit,
+//    instead of a 4th out-of-alphabet sentinel char). This sacrifices
+//    schema keys 59-61 from 1 char to 2 (there's no way to add a 2-char
+//    escape range without giving up SOME direct-range chars — see
+//    `COMPACT_DIRECT_LIMIT`'s doc) but nets a strict win the moment more
+//    than 3 keys sit past the direct range, true of every schema this codec
+//    packs today (`fieldSynthSchema` alone is 208 keys).
+// 2. Run/list tokens for repeated values. A schema built from repeated
+//    per-voice/per-layer key FAMILIES (field1..field9, phase1..phase9, ...)
+//    routinely gets the SAME override value on several of those keys at
+//    once (e.g. the same custom phase on every voice, or a boolean flag
+//    turned on for layers 1 and 2) — both as CONSECUTIVE schema indices
+//    (`RUN_MARKER`) and as a scattered set sharing one value
+//    (`LIST_MARKER`). Emitting the value once instead of once per key saves
+//    real characters on exactly the patches a modular-synth-style UI
+//    produces.
+//
+// Both new marker characters (`_` run, `*` list) are OUTSIDE the BASE62
+// alphabet, so — like `INDEX_ESCAPE` before them — they can only ever be
+// read as a marker at a fresh token-start position and never misread as
+// mid-value content; both also survive `URLSearchParams` unescaped (a `~`
+// or `^` sentinel would silently cost 3 chars of percent-encoding per
+// occurrence — verified empirically before picking these two). This is a
+// SEPARATE, incompatible grammar from the legacy pair above (a legacy `_`
+// 2-digit index escape and this format's `_` run marker are never decoded
+// by the same function), so reusing `_` here is safe: nothing ever feeds a
+// legacy-format string into this decoder or vice versa — each consumer's
+// own outer version tag routes a packed `paramsPacked`/`effectParams`/
+// `params` string to exactly one of the two paired functions, never both.
+
+// A single direct BASE62 char covers values 0..58; values 59+ use a 2-char
+// escape whose first char is one of BASE62's own top 3 characters (indices
+// 59/60/61 — 'X'/'Y'/'Z'), so there is no separate out-of-alphabet sentinel
+// (that's what makes this 2 chars instead of the legacy escape's 3). Any
+// self-delimiting scheme that keeps ALL 62 characters in the direct range
+// needs an extra out-of-band sentinel to signal "2 chars follow" — the
+// tradeoff here is sacrificing a FEW of the highest direct values (59-61)
+// as escape-start selectors instead. 3 selector chars × 62 second-char
+// values covers escaped values 59..244, comfortably past `fieldSynthSchema`
+// today (max index 207); a schema that outgrows 244 keys needs another
+// escape tier and, since that changes the wire format, another version
+// bump the same way this one did.
+const COMPACT_DIRECT_LIMIT = 59;
+const COMPACT_ESCAPE_CHARS = "XYZ";
+const RUN_MARKER = "_";
+const LIST_MARKER = "*";
+const COMPACT_MAX_GROUP = BASE62.length - 1; // count is a single BASE62 char, so 1..61
+
+function encodeCompactIndex(index: number): string {
+  if (index < COMPACT_DIRECT_LIMIT) return BASE62[index]!;
+  const rel = index - COMPACT_DIRECT_LIMIT;
+  const hi = Math.floor(rel / BASE62.length);
+  const lo = rel % BASE62.length;
+  if (hi >= COMPACT_ESCAPE_CHARS.length) {
+    throw new Error(`urlState: schema index ${index} exceeds the compact codec's representable range — widen COMPACT_ESCAPE_CHARS (needs a new version bump for every consumer).`);
+  }
+  return `${COMPACT_ESCAPE_CHARS[hi]}${BASE62[lo]}`;
+}
+
+function decodeCompactIndex(raw: string, index: number): { value: number; next: number } | undefined {
+  const char = raw[index];
+  if (char === undefined) return undefined;
+  const hi = COMPACT_ESCAPE_CHARS.indexOf(char);
+  if (hi >= 0) {
+    const lo = fromBase62Char(raw[index + 1]);
+    if (lo === undefined) return undefined;
+    return { value: COMPACT_DIRECT_LIMIT + hi * BASE62.length + lo, next: index + 2 };
+  }
+  const i = fromBase62Char(char);
+  return i === undefined ? undefined : { value: i, next: index + 1 };
+}
+
+/** Two schema keys can safely share ONE encoded value token only when
+ *  decoding that token means the same thing for both — same `kind`, and for
+ *  `"number"` the same rounding `step`, for enum-like `"string"` the same
+ *  `values` list. `kind` alone is NOT enough: e.g. `freq*` (step 0.1) and
+ *  `amp*` (step 0.05) are both `"number"` and can coincidentally encode the
+ *  same digit string for two DIFFERENT real values (caught in design — see
+ *  commit message) — grouping them by raw encoded string alone would have
+ *  silently swapped a decoded value's real magnitude between keys. */
+function specGroupKey(spec: EffectParamSpecLike): string {
+  if (spec.kind === "number") return `n:${specStep(spec)}`;
+  if (spec.kind === "string" && spec.values) return `e:${spec.values.join(" ")}`;
+  return spec.kind;
+}
+
+interface CompactCandidate {
+  readonly index: number;
+  readonly name: string;
+  readonly spec: EffectParamSpecLike;
+  readonly encoded: string;
+}
+
+function collectCompactCandidates(
+  schema: EffectParamSchemaLike,
+  defaults: Record<string, unknown>,
+  values: Record<string, unknown>,
+  skipKeys: readonly string[],
+): CompactCandidate[] {
+  const keys = Object.keys(schema);
+  const candidates: CompactCandidate[] = [];
+  for (let index = 0; index < keys.length; index++) {
+    const name = keys[index]!;
+    if (skipKeys.includes(name) || !(name in values)) continue;
+    const spec = schema[name];
+    if (!spec) continue;
+    const value = values[name];
+    if (sameSpecValue(spec, value, defaults[name])) continue;
+    const encoded = encodeSpecValue(spec, value);
+    if (encoded === undefined) continue;
+    candidates.push({ index, name, spec, encoded });
+  }
+  return candidates;
+}
+
+/** Diff `values` against `defaults` and pack the overrides against `schema`
+ *  using the compact v2 token grammar (see the file section doc above):
+ *  plain `<index><value>` tokens, `RUN_MARKER`-prefixed runs for identical
+ *  values at CONSECUTIVE schema indices, and `LIST_MARKER`-prefixed lists
+ *  for identical values at scattered indices (only when that's actually
+ *  cheaper than repeating the value — see the per-group cost check below;
+ *  unlike a run, a list still has to spell out every member's index, so
+ *  grouping isn't a free win for a 2-member, 1-char-value group). Returns
+ *  "" for no overrides. `time`/`skipKeys` are excluded (animated/derived,
+ *  not part of a shareable link). Output order is by schema index, not
+ *  insertion order, so it's stable across calls with the same overrides. */
+export function encodeEffectParamsPacked(
+  schema: EffectParamSchemaLike,
+  defaults: Record<string, unknown>,
+  values: Record<string, unknown>,
+  skipKeys: readonly string[] = ["time"],
+): string {
+  const candidates = collectCompactCandidates(schema, defaults, values, skipKeys);
+  const consumed = new Set<number>(); // positions in `candidates`
+  const tokens: { sortKey: number; text: string }[] = [];
+
+  // Pass 1: maximal consecutive-schema-index runs sharing an identical
+  // (groupable-spec, encoded-value) pair, chunked to `COMPACT_MAX_GROUP` so
+  // the single-char count field never overflows. A run of length >= 2 is
+  // ALWAYS at least as cheap as emitting its members individually: the run
+  // token only pays its (smallest-index) start member's index width once,
+  // while individually-encoded members each pay their own index width,
+  // whose per-member minimum is that same start width (index-encoded width
+  // is monotonic non-decreasing in the index) — so run cost
+  // (2 + startIdxLen + valLen) <= individual lower bound
+  // (2 * (startIdxLen + valLen)) whenever startIdxLen + valLen >= 2, which
+  // always holds (both widths are >= 1 char). No per-group cost check
+  // needed here, unlike the list pass below.
+  let ci = 0;
+  while (ci < candidates.length) {
+    let end = ci;
+    while (
+      end + 1 < candidates.length &&
+      end - ci + 1 < COMPACT_MAX_GROUP &&
+      candidates[end + 1]!.index === candidates[end]!.index + 1 &&
+      candidates[end + 1]!.encoded === candidates[ci]!.encoded &&
+      specGroupKey(candidates[end + 1]!.spec) === specGroupKey(candidates[ci]!.spec)
+    ) {
+      end++;
+    }
+    const runLength = end - ci + 1;
+    if (runLength >= 2) {
+      const start = candidates[ci]!;
+      const text = `${RUN_MARKER}${encodeCompactIndex(start.index)}${BASE62[runLength]}${start.encoded}`;
+      tokens.push({ sortKey: start.index, text });
+      for (let k = ci; k <= end; k++) consumed.add(k);
+      ci = end + 1;
+    } else {
+      ci++;
+    }
+  }
+
+  // Pass 2: among remaining (non-run) singletons, group by identical
+  // (groupable-spec, encoded-value) regardless of adjacency, chunked to
+  // `COMPACT_MAX_GROUP`. A list token is worth it only when
+  // `(count - 1) * valueLength > 2` (the list's own marker + count-char
+  // overhead) — every member's index has to be spelled out either way, so
+  // the only real saving is not repeating the value `count - 1` extra
+  // times; a 2-member group sharing a 1-char value (e.g. two enum picks
+  // both landing on index "3") is NOT worth listing and is measurably
+  // worse to (this was checked against a real link during design, not
+  // assumed).
+  const groups = new Map<string, number[]>();
+  for (let k = 0; k < candidates.length; k++) {
+    if (consumed.has(k)) continue;
+    const c = candidates[k]!;
+    const key = `${specGroupKey(c.spec)}|${c.encoded}`;
+    const list = groups.get(key);
+    if (list) list.push(k);
+    else groups.set(key, [k]);
+  }
+  for (const positions of groups.values()) {
+    for (let start = 0; start < positions.length; start += COMPACT_MAX_GROUP) {
+      const chunk = positions.slice(start, start + COMPACT_MAX_GROUP);
+      if (chunk.length < 2) continue;
+      const first = candidates[chunk[0]!]!;
+      const saving = (chunk.length - 1) * first.encoded.length - 2;
+      if (saving <= 0) continue;
+      for (const p of chunk) consumed.add(p);
+      const indexChars = chunk.map((p) => encodeCompactIndex(candidates[p]!.index)).join("");
+      const text = `${LIST_MARKER}${BASE62[chunk.length]}${indexChars}${first.encoded}`;
+      tokens.push({ sortKey: first.index, text });
+    }
+  }
+
+  // Pass 3: whatever's left is an ordinary single index+value token.
+  for (let k = 0; k < candidates.length; k++) {
+    if (consumed.has(k)) continue;
+    const c = candidates[k]!;
+    tokens.push({ sortKey: c.index, text: `${encodeCompactIndex(c.index)}${c.encoded}` });
+  }
+
+  tokens.sort((a, b) => a.sortKey - b.sortKey);
+  return tokens.map((t) => t.text).join("");
+}
+
+/** Inverse of `encodeEffectParamsPacked`. Never throws: an unknown marker,
+ *  out-of-range index, spec mismatch within a run/list group, or malformed
+ *  value stops decoding and returns whatever parsed so far — same contract
+ *  as the legacy decoder. A run/list group's every member index must
+ *  resolve to a schema key sharing `specGroupKey` with the group's anchor
+ *  spec (the same equality the encoder enforces before grouping); a
+ *  hand-crafted payload that violates this is treated as malformed rather
+ *  than silently writing a value of the wrong shape into an unrelated key. */
+export function decodeEffectParamsPacked(
+  schema: EffectParamSchemaLike,
+  packed: string | undefined,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (!packed) return out;
+  const keys = Object.keys(schema);
+  let index = 0;
+  try {
+    while (index < packed.length) {
+      const marker = packed[index];
+      if (marker === RUN_MARKER) {
+        const startTok = decodeCompactIndex(packed, index + 1);
+        if (!startTok) break;
+        const count = fromBase62Char(packed[startTok.next]);
+        if (count === undefined || count < 2) break;
+        const startName = keys[startTok.value];
+        const startSpec = startName ? schema[startName] : undefined;
+        if (!startName || !startSpec) break;
+        const members: string[] = [];
+        let ok = true;
+        for (let k = 0; k < count; k++) {
+          const memberName = keys[startTok.value + k];
+          const memberSpec = memberName ? schema[memberName] : undefined;
+          if (!memberName || !memberSpec || specGroupKey(memberSpec) !== specGroupKey(startSpec)) { ok = false; break; }
+          members.push(memberName);
+        }
+        if (!ok) break;
+        const decodedValue = decodeSpecValue(startSpec, packed, startTok.next + 1);
+        if (!decodedValue) break;
+        for (const name of members) out[name] = decodedValue.value;
+        index = decodedValue.next;
+        continue;
+      }
+      if (marker === LIST_MARKER) {
+        const count = fromBase62Char(packed[index + 1]);
+        if (count === undefined || count < 2) break;
+        let cursor = index + 2;
+        const members: string[] = [];
+        let firstSpec: EffectParamSpecLike | undefined;
+        let ok = true;
+        for (let k = 0; k < count; k++) {
+          const tok = decodeCompactIndex(packed, cursor);
+          if (!tok) { ok = false; break; }
+          const name = keys[tok.value];
+          const spec = name ? schema[name] : undefined;
+          if (!name || !spec) { ok = false; break; }
+          if (firstSpec === undefined) firstSpec = spec;
+          else if (specGroupKey(spec) !== specGroupKey(firstSpec)) { ok = false; break; }
+          members.push(name);
+          cursor = tok.next;
+        }
+        if (!ok || !firstSpec) break;
+        const decodedValue = decodeSpecValue(firstSpec, packed, cursor);
+        if (!decodedValue) break;
+        for (const name of members) out[name] = decodedValue.value;
+        index = decodedValue.next;
+        continue;
+      }
+      const tok = decodeCompactIndex(packed, index);
+      if (!tok) break;
+      const name = keys[tok.value];
+      const spec = name ? schema[name] : undefined;
+      if (!name || !spec) break;
+      const decodedValue = decodeSpecValue(spec, packed, tok.next);
+      if (!decodedValue) break;
+      out[name] = decodedValue.value;
+      index = decodedValue.next;
     }
   } catch {
     return out;


### PR DESCRIPTION
Unblocks the publish workflow, then fixes the post-release bugs found on `/synth` and `/wordart`.

## The release blocker

`Publish packages` failed in `packages/compile`:

```
Cannot find module '.../packages/compile/node_modules/glyphcss/dist/index.js'
imported from .../packages/compile/.glyph-cli-build-xxx/cli.js
```

The two workflows disagreed on ordering:

```
ci.yml            install → BUILD → test          ✓
publish-packages  install → test → bump → BUILD   ✗
```

`labelParity.test.ts` spawns the real built CLI as a **subprocess**, so that child resolves `glyphcss` through `node_modules` on disk — a vitest alias can't reach it. On a clean CI checkout `packages/glyphcss/dist` doesn't exist yet. It passed locally only because a previous build had left `dist/` behind.

Reproduced by moving `dist` aside locally (same error, same two tests) and confirmed fixed by restoring it. The publish workflow now builds before testing, matching `ci.yml`. The post-bump build is kept deliberately — `dist` doesn't currently embed the package version (the interactive export's CDN version is a runtime option), but if that ever changes the published artifact should carry the bumped value.

## Bugs found after release

- **Static CodePen exports baked at the wrong resolution.** `frameObject` fit `camera.zoom` against measured DOM metrics, but `bake()` reprojected it onto the internal `BASE_TILE` fallback — a 202×78 stage collapsed to a 35×22 window, so the pattern had nothing to resolve with and the pen looked like an unmodulated silhouette. The exporter now accepts the real measured `cellWidthPx`/`cellHeightPx`. A live-vs-pen parity test pins it.
- **The CodePen button could appear dead.** The bake ran synchronously inside the click, so the ~4s of blocked main thread could outlast Chrome's transient user activation and get the popup blocked. The tab is now claimed with `window.open` before any work starts, so bake duration can't decide whether it opens.
- **The Sierpinski pyramid rendered as a diamond.** The corner tetra has exact 3-fold symmetry about world Z, and the default yaw viewed it corner-on. Silhouette taper went 0.51 (widest in the middle) → 4.71 (monotonic, apex-up) by changing yaw only; pitch stays at the angle the vertical-centering solve is calibrated against.
- **The static-export tooltip named the wrong reason.** Enabling the colour voice stack disabled the button while the tooltip still listed volumetric/linearZ/originW. It now reports the exporter's own reject message instead of a hand-maintained mirror.

## URL payloads

Two lossless levers in the shared codec, one version bump per consumer:

- run/list tokens collapsing identical values at consecutive or scattered schema indices
- a 2-char index escape replacing the 3-char `_XY` form

| | before | after |
|---|---|---|
| a reported `/synth` link | 207 | **133** |
| Menger (cssGraphics) | 429 | **239** |
| gallery `?fx=` + field-synth | 406 | **217** |
| wordart `?w=` + field-synth | 403 | **214** |

Compression was measured and rejected: deflate takes the 207-char payload to 144 bytes, but base64url's 4/3 expansion returns 192 — a net 15 chars. Brotli nets 25.

Grouping is keyed by `(kind, step-or-enum)`, not by encoded string: `freq*` (step 0.1) and `amp*` (step 0.05) can encode identical digit strings for different real values, and grouping on the string would have silently swapped magnitudes. The list form is gated on `(count-1) × valueLength > 2` because a 2-member group with a 1-char value costs more than separate tokens. Both are regression tests.

Verified with a 500-trial round-trip fuzz per codec, plus real pre-change links captured from every page and asserted to decode deep-equal afterwards.

## `/synth` and `/wordart`

- **Copy ASCII** on both pages — copies the rendered art (not the code snippet the existing WordArt "Copy" produces), with per-line trailing whitespace trimmed so it pastes usefully. Both export bars are hidden below 760px, so the action is mirrored into the mobile drawer; it would otherwise be unreachable there.
- **WordArt view shortcuts** — the polygon/font readout is replaced by "Still · front face" and "Auto rotate" over the existing `spin`/`turn`/`tilt` URL state.
- **Buttons read as `[ ]`** — full left/right borders plus corner ticks, matching the bracketed sliders and checkboxes. One shared rule driven by a custom property. Segmented toggles are excluded (adjacent buttons share an edge), as are controls that already render literal `[ ]` text.

## Verification

`pnpm test` (core 775, glyphcss 631, effects 664, vue 188, react 183, fonts 55, compile 32, website 239) and `pnpm build` green. The publish failure was reproduced locally before fixing and confirmed resolved after.
