### PR TITLE
perf(scene): cache the autoSize host box instead of measuring it every render

### DIFF
--- a/packages/glyphcss/src/api/createGlyphScene.hostRect.test.ts
+++ b/packages/glyphcss/src/api/createGlyphScene.hostRect.test.ts
@@ -1,0 +1,99 @@
+/**
+ * `baseProjectionGrid()` re-centers an `autoSize` scene's projection from the
+ * HOST element's box. That read is a forced synchronous layout flush, and it sat
+ * on the per-render path: every camera frame measured the host again even though
+ * its box only changes when the host resizes.
+ *
+ * Profiled in a real browser (a moving first-person scene, 353x120 cells), the
+ * host measurement was the single largest cost in the frame — larger than the
+ * rasteriser — at ~4.4ms/frame of layout, and caching it moved that scene from
+ * 70fps to 98fps. So the host box is cached with the same lifetime as the cell
+ * probes beside it: invalidated by `fitToHost()`, which is both the
+ * ResizeObserver callback and the public `fit()`.
+ *
+ * Only width/height are read, so a scroll (which moves x/y and fires no resize)
+ * cannot stale the cache.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createGlyphScene } from "./createGlyphScene";
+import { createGlyphOrthographicCamera } from "./createGlyphCamera";
+import type { Polygon } from "@glyphcss/core";
+
+const HOST_W = 640;
+const HOST_H = 320;
+
+function rect(width: number, height: number): DOMRect {
+  return { width, height, top: 0, left: 0, right: width, bottom: height, x: 0, y: 0, toJSON: () => ({}) } as DOMRect;
+}
+
+/**
+ * Counts layout reads against the HOST element only, so the base/detail cell
+ * probes (hidden `<span>`/`<pre>` children) can't be mistaken for host reads.
+ *
+ * jsdom has no layout engine, so this also gives the probes a realistic
+ * monospace advance — without it `measureCellOf`'s zero-size fallback leaves
+ * `cell.measured` false and the `autoSize` branch under test never runs at all,
+ * which would pass whether or not the fix is present.
+ */
+function countHostReads(host: HTMLElement): { calls: () => number; reset: () => void } {
+  let n = 0;
+  vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(function (this: Element) {
+    const el = this as HTMLElement;
+    if (el === host) {
+      n++;
+      return rect(HOST_W, HOST_H);
+    }
+    const fontSizePx = parseFloat(/font-size:\s*([\d.]+)px/.exec(el.style.cssText)?.[1] ?? "16");
+    const lines = (el.textContent ?? "").split("\n").length || 1;
+    return rect(fontSizePx * 0.6, fontSizePx * 1.2 * lines);
+  });
+  return { calls: () => n, reset: () => { n = 0; } };
+}
+
+function quad(): Polygon[] {
+  return [{ vertices: [[-3, -3, 0], [-3, 3, 0], [3, 3, 0], [3, -3, 0]], color: "#8899aa" }];
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+});
+
+describe("createGlyphScene — autoSize host measurement is not a per-frame layout flush", () => {
+  it("does not re-measure the host on steady-state camera renders", () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const probe = countHostReads(host);
+
+    const camera = createGlyphOrthographicCamera({ rotX: 0, rotY: 0, zoom: 1 });
+    const scene = createGlyphScene(host, { autoSize: true, cols: 40, rows: 20, camera });
+    scene.add(quad());
+    scene.rerender(); // cold fill: the first frame after a fit legitimately measures once
+
+    probe.reset();
+    for (let i = 0; i < 12; i++) {
+      camera.rotY = i * 3;
+      scene.rerender();
+    }
+
+    // Before the fix this was one host layout flush per render (12).
+    expect(probe.calls()).toBe(0);
+  });
+
+  it("re-measures the host after fit(), so a resize still re-centers", () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const probe = countHostReads(host);
+
+    const camera = createGlyphOrthographicCamera({ rotX: 0, rotY: 0, zoom: 1 });
+    const scene = createGlyphScene(host, { autoSize: true, cols: 40, rows: 20, camera });
+    scene.add(quad());
+    scene.rerender();
+
+    probe.reset();
+    scene.fit();
+    scene.rerender();
+
+    expect(probe.calls()).toBeGreaterThan(0);
+  });
+});

--- a/packages/glyphcss/src/api/createGlyphScene.ts
+++ b/packages/glyphcss/src/api/createGlyphScene.ts
@@ -1292,7 +1292,7 @@ export function createGlyphScene(
       grid.cellHeight = cell.h;
     }
     if (options.autoSize && cell.measured && cell.w > 0 && cell.h > 0) {
-      const r = host.getBoundingClientRect();
+      const r = hostBox();
       if (r.width > 0) {
         grid.centerCol = options.cols * options.camera.center[0] + (r.width - options.cols * cell.w) / (2 * cell.w);
       }
@@ -1301,6 +1301,19 @@ export function createGlyphScene(
       }
     }
     return grid;
+  }
+  // Same forced-layout flush as the cell probes above, and the same lifetime: this
+  // only re-centers the projection when the HOST's box changes, which is exactly
+  // what fitToHost() (the ResizeObserver callback, and the public `fit()`) already
+  // reacts to. Reading it inside baseProjectionGrid() meant a synchronous layout on
+  // every camera frame — in a moving scene at high density that was the single
+  // largest cost in the frame, above the rasteriser itself. Only width/height are
+  // read, so scrolling (which moves x/y but fires no resize) can't stale it.
+  let hostRectCache: { width: number; height: number } | null = null;
+  function hostBox(): { width: number; height: number } {
+    if (hostRectCache) return hostRectCache;
+    const r = host.getBoundingClientRect();
+    return (hostRectCache = { width: r.width, height: r.height });
   }
   let baseFontPxCache: number | null = null;
   function baseFontPx(): number {
@@ -2011,7 +2024,7 @@ export function createGlyphScene(
         savedInteractCols = options.cols; savedInteractRows = options.rows;
         options.cols = Math.max(2, Math.round(options.cols / ds));
         options.rows = Math.max(2, Math.round(options.rows / ds));
-        baseCellCache = null; baseFontPxCache = null;
+        baseCellCache = null; baseFontPxCache = null; hostRectCache = null;
       }
     } else {
       pre.style.fontSize = savedInteractFont ?? "";
@@ -2019,7 +2032,7 @@ export function createGlyphScene(
         fitToHost();
       } else {
         options.cols = savedInteractCols; options.rows = savedInteractRows;
-        baseCellCache = null; baseFontPxCache = null;
+        baseCellCache = null; baseFontPxCache = null; hostRectCache = null;
       }
       savedInteractFont = null;
     }
@@ -2158,7 +2171,7 @@ export function createGlyphScene(
   }
 
   function fitToHost(): void {
-    baseCellCache = null; baseFontPxCache = null; // host/cell size may have changed
+    baseCellCache = null; baseFontPxCache = null; hostRectCache = null; // host/cell size may have changed
     const w = host.clientWidth;
     const h = host.clientHeight;
     if (!w || !h) return;


### PR DESCRIPTION
`baseProjectionGrid()` re-centers an `autoSize` scene's projection from the host element's box. That read is a forced synchronous layout flush and it sat on the per-render path, so every camera frame measured the host again — even though its box only changes when the host resizes.

Profiled in a real browser (moving first-person scene, 353x120 cells) the host measurement was the single largest cost in the frame, above the rasteriser, at ~4.4ms/frame of layout. Caching it took that scene from 70fps to 98fps.

The host box is now cached with the same lifetime as the cell probes beside it, invalidated by `fitToHost()` — which is both the `ResizeObserver` callback and the public `fit()`. Only width/height are read, so a scroll (which moves x/y and fires no resize) cannot stale it.

`baseProjectionGrid()` runs twice per render, so this removes two layout flushes per frame.

## Verification

`pnpm test` and `pnpm build` green. The new test counts layout reads against the host element only, so the base/detail cell probes can't be mistaken for host reads: 12 steady-state camera renders go from 24 host flushes to 0, and a second test asserts `fit()` still re-measures so a resize re-centers.
